### PR TITLE
Bring focus on SVG editor if clicked.

### DIFF
--- a/static/code/svg.js
+++ b/static/code/svg.js
@@ -431,4 +431,5 @@ svgEditor.menuClick = function(e) {
 
 window.addEventListener('load', svgEditor.init);
 window.addEventListener('resize', svgEditor.resize);
+window.addEventListener('mousedown', window.focus);
 setInterval(svgEditor.updateToolbox, 250);


### PR DESCRIPTION
Previously it could take a lot of UI interactions before focus finally lands on the SVG editor.  The result is that keyboard shortcuts for cut/copy/paste/delete/undo/redo would silently fail.