### PR TITLE
Partial support of JSON.stringify args.

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2046,11 +2046,18 @@ Interpreter.prototype.initJSON_ = function() {
       throw new intrp.Error(intrp.thread_.perms(), intrp.TYPE_ERROR,
           'Function replacer on JSON.stringify not supported');
     } else if (replacer instanceof intrp.Array) {
-      replacer = intrp.pseudoToNative(replacer);
+      replacer = intrp.createListFromArrayLike(replacer);
+      replacer = replacer.filter(function(word) {
+        // Spec says we should also support boxed primitives here.
+        return typeof word === 'string' || typeof word === 'number';
+      });
     } else {
       replacer = null;
     }
-    space = Number(space);
+    // Spec says we should also support boxed primitives here.
+    if (typeof space !== 'string' && typeof space !== 'number') {
+      space = undefined;
+    }
     try {
       var str = JSON.stringify(nativeObj, replacer, space);
     } catch (e) {
@@ -2075,7 +2082,7 @@ Interpreter.prototype.initWeakMap_ = function() {
     id: 'WeakMap', length: 0,  // N.B. length is correct; arg is optional!
     /** @type {!Interpreter.NativeConstructImpl} */
     construct: function(intrp, thread, state, args) {
-      // TODO(cpcallen): Support interator argument to populate map.
+      // TODO(cpcallen): Support iterable argument to populate map.
       return new intrp.WeakMap(state.scope.perms);
     }
   });

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -2667,7 +2667,11 @@ tests.JsonStringify = function () {
 
   str = '{\n  "string": "foo",\n  "number": 42\n}';
   console.assert(JSON.stringify(obj, ['string', 'number'], 2) === str,
-      'JSON.stringify pretty');
+      'JSON.stringify pretty number');
+
+  str = '{\n--"string": "foo",\n--"number": 42\n}';
+  console.assert(JSON.stringify(obj, ['string', 'number'], '--') === str,
+      'JSON.stringify pretty string');
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -2606,13 +2606,37 @@ module.exports = [
   /////////////////////////////////////////////////////////////////////////////
   // JSON
 
-  { name: 'JSON.stringify', src: `
+  { name: 'JSON.stringify basic', src: `
     JSON.stringify({
         string: 'foo', number: 42, true: true, false: false, null: null,
         object: { obj: {}, arr: [] }, array: [{}, []] });
     `,
     expected: '{"string":"foo","number":42,"true":true,"false":false,' +
         '"null":null,"object":{"obj":{},"arr":[]},"array":[{},[]]}' },
+
+  { name: 'JSON.stringify filter', src: `
+    JSON.stringify({
+        string: 'foo', number: 42, true: true, false: false, null: null,
+        object: { obj: {}, arr: [] }, array: [{}, []] },
+        ['string', 'number']);
+    `,
+    expected: '{"string":"foo","number":42}' },
+
+  { name: 'JSON.stringify pretty number', src: `
+    JSON.stringify({
+        string: 'foo', number: 42, true: true, false: false, null: null,
+        object: { obj: {}, arr: [] }, array: [{}, []] },
+        ['string', 'number'], 2);
+    `,
+    expected: '{\n  "string": "foo",\n  "number": 42\n}' },
+
+  { name: 'JSON.stringify pretty string', src: `
+    JSON.stringify({
+        string: 'foo', number: 42, true: true, false: false, null: null,
+        object: { obj: {}, arr: [] }, array: [{}, []] },
+        ['string', 'number'], '--');
+    `,
+    expected: '{\n--"string": "foo",\n--"number": 42\n}' },
 
   /////////////////////////////////////////////////////////////////////////////
   // Other built-in functions


### PR DESCRIPTION
Support pretty printing.  Support array filtering.  Do not support function replacers (this would need to be a polyfill).

The array test is strict since testing showed that array-like replacers do not function:
JSON.stringify({'hello': 1, 'world': 2}, {'0': 'world', 'length': 1}, 2)