### PR TITLE
Security improvments

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -413,14 +413,14 @@ Interpreter.prototype.pause = function() {
         var server = this.listeners_[Number(port)];
         server.listen(undefined, function(error) {
           // Something went wrong while re-listening.  Maybe port in use.
-          this.log('net', 'Re-listen on port %s failed: %s: %s', server.port,
-                      error.name, error.message);
+          intrp.log('net', 'Re-listen on port %s failed: %s: %s', server.port,
+                    error.name, error.message);
           // Report this to userland by calling .onError on proto
           // (with this === proto) - for lack of a better option.
           if (!server.owner) return;
           var func = server.proto.get('onError', server.owner);
           if (!(func instanceof intrp.Function)) return;
-          var userError = intrp.nativeToPseudo(error, server.owner);
+          var userError = intrp.errorNativeToPseudo(error, server.owner);
           // TODO(cpcallen:perms): Is server.owner the correct owner
           // for this thread?  Note that this will typically be root,
           // and .onError will therefore get caller perms === root,
@@ -5547,8 +5547,8 @@ Interpreter.prototype.installTypes = function() {
       if (func instanceof intrp.Function && server.owner !== null) {
         // TODO(cpcallen:perms): Is server.owner the correct owner for
         // this thread?  Note that this will typically be root, and
-        // .onError will therefore get caller perms === root, which is
-        // probably dangerous.  Here and several places below.
+        // .onConnect will therefore get caller perms === root, which
+        // is probably dangerous.  Here and several places below.
         intrp.createThreadForFuncCall(
             server.owner, func, obj, [], undefined, server.timeLimit);
       }

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -1382,6 +1382,7 @@ exports.testNetworking = async function(t) {
       resolve('OK');
    `;
   await runAsyncTest(t, name, src, 'OK', {options: {noLog: ['net']}});
+
   // Run test of the xhr() function using HTTP.
   name = 'testXhrHttp';
   const httpTestServer = http.createServer(function (req, res) {


### PR DESCRIPTION
Investigating the implications of [JS-Interpreter bug #181](https://github.com/NeilFraser/JS-Interpreter/issues/181), no serious problems were found but some small improvements were made as a precaution:

* Added type checks to `createNativeFunction`, `nativeToPseudo`, `pseudoToNative`, `createArrayFromList` and `errorNativeToPseudo`, to make them harder to subvert.
* Changed `pseudoToNative` to use `Object.defineProperty` instead of subscript assignment, to prevent setters be called—e.g., causing the native object's prototype to be modified via `.__proto__`.
* Fix some issues around errors when re-listening a port, including using `errorPseudoToNative` instead of `pseudoToNative` to do the conversion.