### PR TITLE
Throw TypeError if second arg to connectionWrite isn't a string

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2454,8 +2454,11 @@ Interpreter.prototype.initNetwork_ = function() {
       if (!(obj instanceof intrp.Object) || !obj.socket) {
         throw new intrp.Error(state.scope.perms, intrp.TYPE_ERROR,
             'object is not connected');
+      } else if (typeof data !== 'string') {
+        throw new intrp.Error(state.scope.perms, intrp.TYPE_ERROR,
+            'data is not a string');
       }
-      obj.socket.write(String(data));
+      obj.socket.write(data);
     }
   });
 


### PR DESCRIPTION
Previously we just cast to string, but in some cases it would be better to know that we're attempting to transmit something that's not a string.