### PR TITLE
Fix pathological code RegExps

### DIFF
--- a/server/code.js
+++ b/server/code.js
@@ -37,21 +37,21 @@ regexps.escapes = /\\(?:["'\\\/0bfnrtv]|u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2})/g;
  * "'it\\'s'".
  */
 regexps.singleQuotedString =
-    new RegExp("'(?:[^\'\\\\]+|" + regexps.escapes.source + ")*'");
+    new RegExp("'(?:[^'\\\\]|" + regexps.escapes.source + ")*'", 'g');
 
 /**
  * Matches a double-quoted string literal, like '"this one"' and
  * '"it\'s"'.
  */
 regexps.doubleQuotedString =
-    new RegExp('"(?:[^\"\\\\]+|' + regexps.escapes.source + ')*"');
+    new RegExp('"(?:[^"\\\\]|' + regexps.escapes.source + ')*"', 'g');
 
 /**
  * Matches a string literal, like "'this one' and '"that one"' as well
  * as "the 'string literal' substring of this longer string" too.
  */
 regexps.string = new RegExp('(?:' + regexps.singleQuotedString.source + '|' +
-    regexps.doubleQuotedString.source + ')');
+    regexps.doubleQuotedString.source + ')', 'g');
 
 /**
  * Matches exaclty a string literal, like "'this one'" but notably not

--- a/server/tests/code_test.js
+++ b/server/tests/code_test.js
@@ -88,6 +88,10 @@ exports.testParseString = function(t) {
     `'\\x1G'`,
     `'\\u1g00'`,
     `'\\u1G00'`,
+    // Pathological cases that previously caused exponential
+    // backtracking.
+    `'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`,
+    `"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`,
   ];
   for (const tc of badCases) {
     try {


### PR DESCRIPTION
The RegExps for matching single- and double-quoted strings were inadvertently prone to exponential backtracking on strings that began with a quote character but did not terminate with one.

This is in aid of issue #325.

While I'm at it, make all the non-`exact` RegExps global, for consistency with regexps.singleQuotedString.