### PR TITLE
More nginx config improvments

### DIFF
--- a/etc/cc-localhost.conf
+++ b/etc/cc-localhost.conf
@@ -22,7 +22,7 @@ server {
 
   location / {
     # Proxy to Code City port 7780.
-    proxy_pass         http://localhost:7780/;
+    proxy_pass http://127.0.0.1:7780/;
   }
 
   location /static/ {
@@ -36,16 +36,16 @@ server {
 
   location /login {
     # Proxy to loginServer.js port 7781.
-    proxy_pass         http://localhost:7781/login;
+    proxy_pass http://127.0.0.1:7781/login;
   }
 
   location /connect {
     # Proxy to connectServer.js port 7782.
-    proxy_pass         http://localhost:7782/connect;
+    proxy_pass http://127.0.0.1:7782/connect;
   }
 
   location /mobwrite {
     # Proxy to mobwrite_server.py port 7783.
-    proxy_pass         http://localhost:7783/mobwrite;
+    proxy_pass http://127.0.0.1:7783/mobwrite;
   }
 }

--- a/etc/cc-localhost.conf
+++ b/etc/cc-localhost.conf
@@ -17,7 +17,8 @@ proxy_send_timeout 10s;
 proxy_read_timeout 10s;
 
 server {
-  listen 8080;
+  # Listen on port 8080 for both IPv6 and IPv4.
+  listen [::]:8080 ipv6only=off;
 
   location / {
     # Proxy to Code City port 7780.

--- a/etc/cc-localhost.conf
+++ b/etc/cc-localhost.conf
@@ -9,6 +9,7 @@
 error_page 502 503 504 =503 /static/503.html;
 
 proxy_set_header Host $http_host;
+proxy_pass_header Server;
 proxy_next_upstream_tries 1;
 proxy_max_temp_file_size 0;
 proxy_connect_timeout 10s;

--- a/etc/cc-onedomain.conf
+++ b/etc/cc-onedomain.conf
@@ -21,11 +21,10 @@ server {
     return 301 https://$host$request_uri;
   }
 
+  # Serve ACME challenge files to enable automatic Certbot SSL
+  # certificate renewals using HTTP-01 challenges.
   location /.well-known/ {
-    # Serve ACME challenge files to enable automatic Certbot SSL
-    # certificate renewals using HTTP-01 challenges.
-    #
-    # We serve these from the usual Debain default path so it doesn't
+    # Serve these from the usual Debain default path so it doesn't
     # matter whether this config file is installed yet or not, and to
     # avoid having certbot have to write to /home/codecity/
     root /var/www/html;

--- a/etc/cc-onedomain.conf
+++ b/etc/cc-onedomain.conf
@@ -53,7 +53,7 @@ server {
 
   location / {
     # Proxy to Code City port 7780.
-    proxy_pass         http://localhost:7780/;
+    proxy_pass http://127.0.0.1:7780/;
   }
 
   location /static/ {
@@ -68,16 +68,16 @@ server {
 
   location /login {
     # Proxy to loginServer.js port 7781.
-    proxy_pass         http://localhost:7781/login;
+    proxy_pass http://127.0.0.1:7781/login;
   }
 
   location /connect {
     # Proxy to connectServer.js port 7782.
-    proxy_pass         http://localhost:7782/connect;
+    proxy_pass http://127.0.0.1:7782/connect;
   }
 
   location /mobwrite {
     # Proxy to mobwrite_server.py port 7783.
-    proxy_pass         http://localhost:7783/mobwrite;
+    proxy_pass http://127.0.0.1:7783/mobwrite;
   }
 }

--- a/etc/cc-onedomain.conf
+++ b/etc/cc-onedomain.conf
@@ -14,7 +14,8 @@ proxy_read_timeout 10s;
 
 # Redirect all http traffic to https, except for ACME HTTP-01 challenges.
 server {
-  listen 80;
+  # Listen on port 80 for both IPv6 and IPv4.
+  listen [::]:80 ipv6only=off;
 
   location  / {
     # Replace INSTANCENAME with the domain name of your instance.  If
@@ -36,7 +37,8 @@ server {
 
 # Code City configuration
 server {
-  listen 443 ssl;
+  # Listen on port 443 for both IPv6 and IPv4.
+  listen [::]:443 ssl ipv6only=off;
 
   # Replace INSTANCENAME with the domain name of your instance.  Make
   # sure that the resulting filenames point at the certificate files

--- a/etc/cc-onedomain.conf
+++ b/etc/cc-onedomain.conf
@@ -18,10 +18,7 @@ server {
   listen [::]:80 ipv6only=off;
 
   location  / {
-    # Replace INSTANCENAME with the domain name of your instance.  If
-    # you have more than one domain name for you instance, put the
-    # canonical one here.
-    return 301 https://INSTANCENAME$request_uri;
+    return 301 https://$host$request_uri;
   }
 
   location /.well-known/ {

--- a/etc/cc-onedomain.conf
+++ b/etc/cc-onedomain.conf
@@ -5,6 +5,7 @@
 error_page 502 503 504 =503 /static/503.html;
 
 proxy_set_header Host $http_host;
+proxy_pass_header Server;
 proxy_next_upstream_tries 1;
 proxy_max_temp_file_size 0;
 proxy_connect_timeout 10s;

--- a/etc/cc-subdomain.conf
+++ b/etc/cc-subdomain.conf
@@ -48,7 +48,7 @@ server {
 
   location / {
     # Proxy to Code City port 7780.
-    proxy_pass         http://localhost:7780/;
+    proxy_pass http://127.0.0.1:7780/;
   }
 }
 
@@ -63,7 +63,7 @@ server {
 
   location / {
     # Proxy to loginServer.js port 7781.
-    proxy_pass         http://localhost:7781/;
+    proxy_pass http://127.0.0.1:7781/;
   }
 }
 
@@ -78,7 +78,7 @@ server {
 
   location / {
     # Proxy to connectServer.js port 7782.
-    proxy_pass         http://localhost:7782/;
+    proxy_pass http://127.0.0.1:7782/;
   }
 }
 
@@ -93,7 +93,7 @@ server {
 
   location / {
     # Proxy to mobwrite_server.py port 7783.
-    proxy_pass         http://localhost:7783/mobwrite;
+    proxy_pass http://127.0.0.1:7783/mobwrite;
   }
 }
 

--- a/etc/cc-subdomain.conf
+++ b/etc/cc-subdomain.conf
@@ -4,6 +4,7 @@
 error_page 502 503 504 =503 /static/503.html;
 
 proxy_set_header Host $http_host;
+proxy_pass_header Server;
 proxy_next_upstream_tries 1;
 proxy_max_temp_file_size 0;
 proxy_connect_timeout 10s;

--- a/etc/cc-subdomain.conf
+++ b/etc/cc-subdomain.conf
@@ -1,7 +1,10 @@
 # Nginx configuration for Code City using multiple subdomains.
 
 # Configuration applying to all servers.
-error_page 502 503 504 =503 /static/503.html;
+# Replace INSTANCENAME with the domain name of your instance; make
+# sure the result is prefixed with the 'static' subdomain.
+# E.g.: static.example.codecity.world
+error_page 502 503 504 =503 https://static.INSTANCENAME/503.html;
 
 proxy_set_header Host $http_host;
 proxy_pass_header Server;

--- a/etc/cc-subdomain.conf
+++ b/etc/cc-subdomain.conf
@@ -23,9 +23,9 @@ server {
   # Listen on port 443 for both IPv6 and IPv4.
   listen [::]:443 ssl ipv6only=off;
 
-  # Replace INSTANCENAME with the base domain name of your instance.
-  # Make sure that the resulting filenames point at the certificate
-  # files created by certbot.
+  # Replace INSTANCENAME with the domain name of your instance.  Make
+  # sure that the resulting filenames point at the certificate files
+  # created by certbot.
   ssl_certificate /etc/letsencrypt/live/INSTANCENAME/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/INSTANCENAME/privkey.pem;
 
@@ -34,14 +34,14 @@ server {
   # # Replace regular expression with one that matches all non-canonical
   # # domains.
   # if ( $host ~ ^example\.codecity\.(academy|games)$ ) {
-  #   # Replace INSTANCENAME with the domain name of your instance.
+  #   # Replace INSTANCENAME with the canonical domain name of your instance.
   #   # E.g.: https://example.codecity.world$request_uri
   #   return 301 https://INSTANCENAME$request_uri;
   # }
   # # Replace regular expression with one that matches all non-canonical
   # # subdomains.
   # if ( $host ~ ^(.*)\.example\.codecity\.(academy|games)$ ) {
-  #   # Replace INSTANCENAME with the domain name of your instance.
+  #   # Replace INSTANCENAME with the canonical domain name of your instance.
   #   # E.g.: https://$1.example.codecity.world$request_uri
   #   return 301 https://$1.INSTANCENAME$request_uri;
   # }
@@ -56,8 +56,8 @@ server {
 server {
   listen [::]:443 ssl;
 
-  # Replace INSTANCENAME with the domain name of your instance,
-  # prefixed with the 'login' subdomain.
+  # Replace INSTANCENAME with the domain name of your instance; make
+  # sure the result is prefixed with the 'login' subdomain.
   # E.g.: login.example.codecity.world
   server_name login.INSTANCENAME;
 
@@ -71,8 +71,8 @@ server {
 server {
   listen [::]:443 ssl;
 
-  # Replace INSTANCENAME with the domain name of your instance,
-  # prefixed with the 'connect' subdomain.
+  # Replace INSTANCENAME with the domain name of your instance; make
+  # sure the result is prefixed with the 'connect' subdomain.
   # E.g.: connect.example.codecity.world
   server_name connect.INSTANCENAME;
 
@@ -86,8 +86,8 @@ server {
 server {
   listen [::]:443 ssl;
 
-  # Replace INSTANCENAME with the domain name of your instance,
-  # prefixed with the 'mobwrite' subdomain.
+  # Replace INSTANCENAME with the domain name of your instance; make
+  # sure the result is prefixed with the 'mobwrite' subdomain.
   # E.g.: mobwrite.example.codecity.world
   server_name mobwrite.INSTANCENAME;
 
@@ -101,8 +101,8 @@ server {
 server {
   listen [::]:443 ssl;
 
-  # Replace INSTANCENAME with the domain name of your instance,
-  # prefixed with the 'static' subdomain.
+  # Replace INSTANCENAME with the domain name of your instance; make
+  # sure the result is prefixed with the 'static' subdomain.
   # E.g.: static.example.codecity.world
   server_name static.INSTANCENAME;
 

--- a/etc/cc-subdomain.conf
+++ b/etc/cc-subdomain.conf
@@ -13,7 +13,8 @@ proxy_read_timeout 10s;
 
 # Redirect all http traffic to https.
 server {
-  listen 80;
+  # Listen on port 80 for both IPv6 and IPv4.
+  listen [::]:80 ipv6only=off;
 
   # Replace INSTANCENAME with the domain name of your instance.  If
   # you have more than one domain name for you instance, put the
@@ -23,7 +24,8 @@ server {
 
 # Code City configuration
 server {
-  listen 443 ssl;
+  # Listen on port 443 for both IPv6 and IPv4.
+  listen [::]:443 ssl ipv6only=off;
 
   # Replace INSTANCENAME with the base domain name of your instance.
   # Make sure that the resulting filenames point at the certificate
@@ -56,7 +58,7 @@ server {
 
 # Login server.
 server {
-  listen 443 ssl;
+  listen [::]:443 ssl;
 
   # Replace INSTANCENAME with the domain name of your instance,
   # prefixed with the 'login' subdomain.
@@ -71,7 +73,7 @@ server {
 
 # Connect server.
 server {
-  listen 443 ssl;
+  listen [::]:443 ssl;
 
   # Replace INSTANCENAME with the domain name of your instance,
   # prefixed with the 'connect' subdomain.
@@ -86,7 +88,7 @@ server {
 
 # MobWrite server.
 server {
-  listen 443 ssl;
+  listen [::]:443 ssl;
 
   # Replace INSTANCENAME with the domain name of your instance,
   # prefixed with the 'mobwrite' subdomain.
@@ -101,7 +103,7 @@ server {
 
 # Static file server.
 server {
-  listen 443 ssl;
+  listen [::]:443 ssl;
 
   # Replace INSTANCENAME with the domain name of your instance,
   # prefixed with the 'static' subdomain.

--- a/etc/cc-subdomain.conf
+++ b/etc/cc-subdomain.conf
@@ -15,11 +15,7 @@ proxy_read_timeout 10s;
 server {
   # Listen on port 80 for both IPv6 and IPv4.
   listen [::]:80 ipv6only=off;
-
-  # Replace INSTANCENAME with the domain name of your instance.  If
-  # you have more than one domain name for you instance, put the
-  # canonical one here.
-  return 301 https://INSTANCENAME$request_uri;
+  return 301 https://$host$request_uri;
 }
 
 # Code City configuration


### PR DESCRIPTION
Main changes:

* Preserve Server header provided by `codecity`.
* Listen on both IPv6 and IPv4.
* Don't canonicalise the domain name when redirecting HTTP->HTTPS.
* Always use (only) IPv4 to connect to backends.  Fixes #416.