### PR TITLE
Update setup instruction: callout links, snapshot scheduling, role accounts

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -199,7 +199,7 @@ Now apply the schedule to your instance’s persistent disk:
 ## Set Up Machine and Install Code City
 
 These instructions assume you are using a GCE instance running Debian
-GNU/Linux 9 (stretch), but feel free to adapt to your particular
+GNU/Linux 10 "buster", but feel free to adapt to your particular
 set-up.
 
 1.  Log into your instance.  (See instructions in first section if
@@ -579,6 +579,8 @@ https://support.google.com/cloud/answer/6158849) for more information.
     ```
 0.  Verify you can connect to your new Code City instance by pointing
     your web browser its domain name—e.g., `https://example.codecity.world`.
+
+Congratulations, you're done!
 
 ## Remote Debugging
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -191,7 +191,7 @@ Now apply the schedule to your instance’s persistent disk:
     https://console.cloud.google.com/compute/disks).
 0.  Click on the name of the persistent disk for your instance.  (By
     default it will have the same name you gave to your instance.)
-0.  Click the pencil icon to edit the disk.
+0.  In the ⋮ menu, choose edit.
 0.  Under Snapshot schedule, select the schedule you created in steps
     1–3.
 0.  Click Save.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -85,6 +85,15 @@ protect.  See [Appendix A: Creating a Service Account](
         *   Recommended: **un**tick “Delete boot disk when instance
             deleted” so that if you _do_ delete your instance you can
             recreate it easily and without losing user data.
+    *   Networking:
+        *   Under Network interfaces, click the pencil icon next to
+            the default interface.
+        *   External IP: ignore this section for now.
+        *   Public DNS PTR Record: optionally click “Enable” and enter
+            the [domain name](#set-up-an-ip-address-and-domain-name)
+            you intend to use for your instance,
+            e.g. <code><em>example</em>.codecity.world</code>.
+        *   Click “Done” to end editing the network interface.
 0.  Double-check the monthly cost estimate to ensure it is reasonable.
 0.  Click “create” and you will be taken back to the VM instances
     dashboard.  After a few minutes, you should see your new instance
@@ -99,60 +108,85 @@ protect.  See [Appendix A: Creating a Service Account](
 [always-free]: https://cloud.google.com/free/docs/gcp-free-tier#always-free-usage-limits
 [service-account]: https://cloud.google.com/iam/docs/creating-managing-service-accounts
 
-### Set up an IP address and domain name
+#### Reserve a Static IP Address
 
-This step is necessary to allow users to connect with your
-newly-created instance.  If you are not using Google Cloud Platform
-you can skip all but the last step.
+For users to be able to access your instance from the Internet, it
+will need a static IP address<sup>[[?]](
+https://en.wikipedia.org/wiki/IP_address) (like 192.0.2.1) so that
+traffic can be routed to it.
 
 1.  Go to the [Networking / External IP addresses
     console](https://console.cloud.google.com/networking/addresses).
-0.  On the line for the instance you’ve just created, under “Type”,
-    choose “Static”.
-    *   In the resulting “Reserve a new static IP address dialog, type
-        in a name (can be any value, but recommend you use the same
-        name as for your instance).
-0.  Now point the domain name for your instance at this new static
-    address.  The details of this are outside of the scope of this
-    document, but we have the following observations and
-    recommendations:
-    *   Setting up DNS<sup>[[?]](
-        https://en.wikipedia.org/wiki/Domain_Name_System)</sup>
-        involves two different entities: the registrar, which assigns
-        you a domain
-        name<sup>[[?]](https://en.wikipedia.org/wiki/Domain_name)</sup>
-        (like `example.org`), and a DNS provider, which runs the name
-        servers<sup>[[?]](https://en.wikipedia.org/wiki/Name_server)</sup>
-        that resolve individual DNS entries (like `www.example.com`)
-        to specific numeric IP addresses like the one created in the
-        previous step.  In some cases both these services will be
-        provided by the same company, but many organisations will
-        typically run their own DNS servers, or outsource it to a
-        [managed DNS provider](
-        https://en.wikipedia.org/wiki/List_of_managed_DNS_providers).
-    *   If you are using your own domain name (e.g.,
-        <code>codecity.<em>example.org</em></code>) this will be done
-        through your DNS provider’s configuration console or via your
-        internal organisational DNS service configuration.
-    *   Alternatively we may in some cases be able to offer you the
-        use of a Code City subdomain (e.g.,
-        <code><em>example</em>.codecity.world</code>), in which case
-        we will take care of this step for you.  Contact us for
-        details.
-    *   Because of the [same origin policy], if you’d like to allow
-        individual (not fully trusted) users of your instance to be
-        able to create their own web pages / servers, we *strongly*
-        recommend that you use a wildcard DNS record<sup>[[?]](
-        https://en.wikipedia.org/wiki/Wildcard_DNS_record)</sup>, so
-        that each user can serve their content on an isolated
-        subdomain (like
-        <code><em>username</em>.example.codecity.world</code>).  To
-        facilitate obtaining the necessary wildcard
-        certificate<sup>[[?]](
-        https://en.wikipedia.org/wiki/Wildcard_certificate)</sup>, we
-        recommend you use a [DNS provider who easily integrates with
-        Let’s Encrypt DNS validation][dns-providers], such as [Google
-        Cloud DNS](https://cloud.google.com/dns/), if possible.
+0.  Click “+ Reserve Static Address”.  Enter details as follows:
+    *   Name: can be any value, but we recommend you use the same name
+        as for your instance.  This is just used to identify the
+        address reservation.
+    *   Description: enter any text you like—e.g.: “Static IP
+        address for <em>example</em>.codecity.world.”
+    *   Network Service Tier: choose either.  See [description of
+        options](https://cloud.google.com/network-tiers/) and [pricing
+        information](https://cloud.google.com/network-tiers/pricing).
+    *   IP vesion: IPv4.
+    *   Type: Regional.
+        *   Region: choose the same region as your instance was
+            created in.
+        *   Attached to: choose your instance from the drop-down.
+0.  Click “Reserve”.
+0.  Make a note of the external address (like 192.0.2.1) which you
+    have just reserved for your instance.
+
+### Give Your Instance a Domain Name
+
+The Domain Name System<sup>[[?]](
+https://en.wikipedia.org/wiki/Domain_Name_System)</sup> is a
+distributed global database that maps domain names (like
+`example.org`) to IP addresses (like 192.0.2.1).
+
+In order for users to be able to access your instance without having
+to know the numeric static IP address you reserved in the previous
+section, you must create a human-readable domain mame<sup>[[?]](
+https://en.wikipedia.org/wiki/Domain_name)</sup> for it.
+
+The details of this process are outside of the scope of this document,
+but we have the following observations and recommendations:
+
+*   Setting up DNS involves two distinct entities: a domain name
+    registrar<sup>[[?]](
+    https://en.wikipedia.org/wiki/Domain_name_registrar)</sup>, from
+    whom you can purchase a domain name (like `example.org`), and a
+    DNS provider, who runs the name servers<sup>[[?]](
+    https://en.wikipedia.org/wiki/Name_server)</sup> that resolve
+    individual DNS entries (like `www.example.com`) to specific
+    numeric IP addresses like the one created in the previous section.
+    
+    In many cases both these services will be provided by the same
+    company, but many organisations will typically run their own DNS
+    servers, or outsource it to a [managed DNS provider](
+    https://en.wikipedia.org/wiki/List_of_managed_DNS_providers).
+
+*   If you are using your own domain name (e.g.,
+    <code>codecity.<em>example.org</em></code>) this will be done
+    through your DNS provider’s configuration console or via your
+    internal organisational DNS service configuration.
+
+*   Alternatively we may in some cases be able to offer you the
+    use of a Code City subdomain (e.g.,
+    <code><em>example</em>.codecity.world</code>), in which case
+    we will take care of this step for you.  Contact us for
+    details.
+
+*   Because of the [same origin policy], if you’d like to allow
+    individual (not fully trusted) users of your instance to be able
+    to create their own web pages / servers, we *strongly* recommend
+    that you use a wildcard DNS record<sup>[[?]](
+    https://en.wikipedia.org/wiki/Wildcard_DNS_record)</sup>, so that
+    each user can serve their content on an isolated subdomain (like
+    <code><em>username</em>.example.codecity.world</code>).  To
+    facilitate obtaining the necessary wildcard certificate<sup>[[?]](
+    https://en.wikipedia.org/wiki/Wildcard_certificate)</sup>, we
+    recommend you use a [DNS provider who easily integrates with Let’s
+    Encrypt DNS validation][dns-providers], such as [Google Cloud
+    DNS](https://cloud.google.com/dns/), if possible.
  
 [same origin policy]: https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy
 [dns-providers]: https://community.letsencrypt.org/t/dns-providers-who-easily-integrate-with-lets-encrypt-dns-validation/86438

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -692,7 +692,7 @@ Now you can create a service account for your instance.
         “CodeCity instance” or “instance-<em>myInstanceName</em>”.
     *   Service account ID: modify suggested ID if desired.
     *   Service account description: “Service account for the
-        <em>exmaple..codecity.world</em> instance” or similar.
+        <em>example</em>.codecity.world instance” or similar.
 0.  Click “Create”.
     *   Where it says “Select a role”, select “CodeCity Instance”.
     *   If you intend to use certbot to obtain a wildcare DNS cert,

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -104,14 +104,15 @@ you can skip all but the last step.
     address.  The details of this are outside of the scope of this
     document, but we have the following observations and
     recommendations:
-    *   Setting up
-        [DNS](https://en.wikipedia.org/wiki/Domain_Name_System)
+    *   Setting up DNS<sup>[[?]](
+        https://en.wikipedia.org/wiki/Domain_Name_System)</sup>
         involves two different entities: the registrar, which assigns
-        you a [domain name](https://en.wikipedia.org/wiki/Domain_name)
-        (like `example.org`), and a DNS provider, which runs the [name
-        servers](https://en.wikipedia.org/wiki/Name_server) that
-        resolve individual DNS entries (like `www.example.com`) to
-        specific numeric IP addresses like the one created in the
+        you a domain
+        name<sup>[[?]](https://en.wikipedia.org/wiki/Domain_name)</sup>
+        (like `example.org`), and a DNS provider, which runs the name
+        servers<sup>[[?]](https://en.wikipedia.org/wiki/Name_server)</sup>
+        that resolve individual DNS entries (like `www.example.com`)
+        to specific numeric IP addresses like the one created in the
         previous step.  In some cases both these services will be
         provided by the same company, but many organisations will
         typically run their own DNS servers, or outsource it to a
@@ -129,16 +130,17 @@ you can skip all but the last step.
     *   Because of the [same origin policy], if you’d like to allow
         individual (not fully trusted) users of your instance to be
         able to create their own web pages / servers, we *strongly*
-        recommend that you use a [wildcard DNS record](
-        https://en.wikipedia.org/wiki/Wildcard_DNS_record), so that
-        each user can serve their content on an isolated subdomain
-        (like
-        <code><em>username</em>.example.codecity.world</code>).
-        To facilitate obtaining the necessary [wildcard certificate](
-        https://en.wikipedia.org/wiki/Wildcard_certificate), we
+        recommend that you use a wildcard DNS record<sup>[[?]](
+        https://en.wikipedia.org/wiki/Wildcard_DNS_record)</sup>, so
+        that each user can serve their content on an isolated
+        subdomain (like
+        <code><em>username</em>.example.codecity.world</code>).  To
+        facilitate obtaining the necessary wildcard
+        certificate<sup>[[?]](
+        https://en.wikipedia.org/wiki/Wildcard_certificate)</sup>, we
         recommend you use a [DNS provider who easily integrates with
         Let’s Encrypt DNS validation][dns-providers], such as [Google
-        Cloud DNS](https://cloud.google.com/dns/) if possible.
+        Cloud DNS](https://cloud.google.com/dns/), if possible.
  
 [same origin policy]: https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy
 [dns-providers]: https://community.letsencrypt.org/t/dns-providers-who-easily-integrate-with-lets-encrypt-dns-validation/86438
@@ -253,10 +255,10 @@ set-up.
 ### Get TLS Certificates
 
 In order to allow incoming HTTPS connections, you will need an
-[TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) [server
-certificate](
+TLS<sup>[[?]](https://en.wikipedia.org/wiki/Transport_Layer_Security)</sup>
+server certificate<sup>[[?]](
 https://en.wikipedia.org/wiki/Public_key_certificate#TLS/SSL_server_certificate
-).  There are two types:
+)</sup>.  There are two types:
 
 *   An ordinary certificate covers one or more specific domain names,
     like `www.example.org`.
@@ -277,8 +279,8 @@ way is to use [Certbot](https://certbot.eff.org/) to get one from
 To use Certbot to get a wildcard certificate, you will need to use the
 [`dns-01` challenge](
 https://letsencrypt.org/docs/challenge-types/#dns-01-challenge), which
-requires being able to create [DNS TXT records](
-https://en.wikipedia.org/wiki/TXT_record) for your domain name.
+requires being able to create DNS TXT records<sup>[[?]](
+https://en.wikipedia.org/wiki/TXT_record)</sup> for your domain name.
 Here’s an example of how to do this if using Google Cloud DNS; see
 [full instructions on the certbot website](
 https://certbot.eff.org/lets-encrypt/debianbuster-nginx) if you use
@@ -480,11 +482,10 @@ nginx.
     *   Name: a suitable full name for your instance, (e.g. “Code City
         for Springfield Highschool”).
     *   Authorized JavaScript origins: may be left blank.
-    *   Authorised redirect URIs: for wildcard DNS configurations this
-        will be of the form
-        <code>https://login.<em>example</em>.codecity.world/</code>;
+    *   Authorized redirect URIs: for wildcard DNS configurations this
+        will be of the form `https://login.example.codecity.world/`;
         for single-domain configurations it will instead be
-        <code><em>example</em>.codecity.world/login</code>.
+        `https://example.codecity.world/login`.
 0.  Click Save.
 0.  Now click on the newly-created client ID.  Make a note of the
     Client ID (it will be a long string like
@@ -530,9 +531,9 @@ https://support.google.com/cloud/answer/6158849) for more information.
     *   Set `password` to a secret, random string.  If you don’t have
         a convenient way to generate one locally, you can copy a
         [random string from random.org].
-    *   Optionally, set `emailRegexp` to a [regexp] matching email
-        addresses which should be permitted to log in to your
-        isntance—e.g., `^.*@myorganisation.org$`.
+    *   Optionally, set `emailRegexp` to a [JavaScript regexp]
+        matching email addresses which should be permitted to log in
+        to your instance—e.g., `^.*@myorganisation.org$`.
 0.  Create and edit a config file for connectServer:
     *   Run connectServer once to create an empty config file:
         ```
@@ -559,7 +560,7 @@ https://support.google.com/cloud/answer/6158849) for more information.
     exit
     ```
 
-[regexp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+[JavaScript regexp]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 [random string from random.org]: https://www.random.org/strings/?num=1&len=20&digits=on&upperalpha=on&loweralpha=on&unique=on&format=html&rnd=new
 
 ### Configure Systemd and Start Code City Servers
@@ -594,15 +595,16 @@ network activity, here’s how to do that:
     ```
     Note the port number (in this case 9229).
 0.  SSH in to the GCE instance again, enabling port forwarding:
-    *   <code>$ <strong>ssh -L 9229:localhost:9229
-        cpcallen@google.codecity.world</strong></code>
+    ```
+    ssh -L 9229:localhost:9229 google.codecity.world
+    ```
     *   The initial 9229 can be replaced with a local port number of
         your choice.
-    *   The <code>:localhost:</code> directive ensures that only
-        processes running on your local machine can make use of the
-        port forward.
+    *   The `:localhost:` directive ensures that only processes
+        running on your local machine can make use of the port
+        forward.
 0.  Open the inspector in Chrome by going to
-    <code>chrome://inspect</code>
+    [`chrome://inspect`](chrome://inspect).
 
 (Based on [node.js debugging documentation](
 https://nodejs.org/en/docs/guides/debugging-getting-started/) and [a


### PR DESCRIPTION
* Use [?] callout links for dictionary definitions.
* Update snapshot-scheduling instructions to reflect small change to GCP console that took too long for me to figure out.
