### PR TITLE
Python 2 required for MobWrite

### DIFF
--- a/bin/startup.command
+++ b/bin/startup.command
@@ -15,7 +15,7 @@ tell app "Terminal"
 ./connectServer"
 
   do script "cd " & basePath & "/mobwrite
-python mobwrite_server.py"
+python2 mobwrite_server.py"
 
   do script "cd " & basePath & "/server
 ./codecity " & basePath & "/database/codecity.cfg"

--- a/etc/codecity-mobwrite.service
+++ b/etc/codecity-mobwrite.service
@@ -8,5 +8,5 @@ SyslogIdentifier=cc-mobwrite
 WorkingDirectory=/home/codecity/CodeCity/mobwrite
 User=codecity
 Group=codecity
-ExecStart=@/usr/bin/python cc-mobwrite /home/codecity/CodeCity/mobwrite/mobwrite_server.py
+ExecStart=@/usr/bin/python2 cc-mobwrite /home/codecity/CodeCity/mobwrite/mobwrite_server.py
 Restart=on-failure

--- a/mobwrite/mobwrite_core_test.py
+++ b/mobwrite/mobwrite_core_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Copyright 2006 Google LLC
 #

--- a/mobwrite/mobwrite_server.py
+++ b/mobwrite/mobwrite_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Copyright 2006 Google LLC
 #


### PR DESCRIPTION
Python 3 throws "No module named 'thread'"