### PR TITLE
Two improvements to Array.prototype builtins

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1437,23 +1437,18 @@ Interpreter.prototype.initArray_ = function() {
     id: 'Array.prototype.toString', length: 0,
     /** @type {!Interpreter.NativeCallImpl} */
     call: function(intrp, thread, state, thisVal, args) {
-      if (!state.info_.funcState) {  // First visit: call .join().
-        state.info_.funcState = true;
-        var perms = state.scope.perms;
-        var obj = intrp.toObject(thisVal, perms);
-        var join = obj.get('join', perms);
-        if (join instanceof intrp.Function) {
-          var func = join;
-        } else {
-          func = /** @type {!Interpreter.prototype.Function} */ (
-              intrp.builtins.get('Object.prototype.toString'));
-        }
-        var newState = Interpreter.State.newForCall(func, thisVal, [], perms);
-        thread.stateStack_.push(newState);
-        return Interpreter.FunctionResult.CallAgain;
-      } else {  // Second visit: return value returned by .join().
-        return state.value;
+      var perms = state.scope.perms;
+      var obj = intrp.toObject(thisVal, perms);
+      var join = obj.get('join', perms);
+      if (join instanceof intrp.Function) {
+        var func = join;
+      } else {
+        func = /** @type {!Interpreter.prototype.Function} */ (
+            intrp.builtins.get('Object.prototype.toString'));
       }
+      var newState = Interpreter.State.newForCall(func, thisVal, [], perms);
+      thread.stateStack_.push(newState);
+      return Interpreter.FunctionResult.AwaitValue;
     }
   });
 

--- a/server/startup/es5.js
+++ b/server/startup/es5.js
@@ -652,13 +652,13 @@ Array.prototype.sort = function sort(comparefn) {
     delete obj[i];
   }
       
-  Array.prototype.sort.quickSort(obj, 0, definedCount, comparefn);
+  Array.prototype.sort.quicksort_(obj, 0, definedCount, comparefn);
   return obj;
 };
 Object.defineProperty(Array.prototype, 'sort', {enumerable: false});
 
 // Helper functions.
-Array.prototype.sort.insertionSort = function insertionSort(
+Array.prototype.sort.insertionSort_ = function insertionSort_(
     a, from, to, comparefn) {
   // For short (length <= 10) arrays, insertion sort is used for efficiency.
   for (var i = from + 1; i < to; i++) {
@@ -675,10 +675,10 @@ Array.prototype.sort.insertionSort = function insertionSort(
     a[j + 1] = element;
   }
 };
-Object.defineProperty(Array.prototype.sort, 'insertionSort',
+Object.defineProperty(Array.prototype.sort, 'insertionSort_',
                       {enumerable: false});
 
-Array.prototype.sort.getThirdIndex = function getThirdIndex(
+Array.prototype.sort.getThirdIndex_ = function getThirdIndex_(
     a, from, to, comparefn) {
   var t_array = [];
   // Use both 'from' and 'to' to determine the pivot candidates.
@@ -696,21 +696,21 @@ Array.prototype.sort.getThirdIndex = function getThirdIndex(
   var third_index = t_array[t_array.length >> 1][0];
   return third_index;
 };
-Object.defineProperty(Array.prototype.sort, 'getThirdIndex',
+Object.defineProperty(Array.prototype.sort, 'getThirdIndex_',
                       {enumerable: false});
 
-Array.prototype.sort.quickSort = function quickSort(a, from, to, comparefn) {
+Array.prototype.sort.quicksort_ = function quicksort_(a, from, to, comparefn) {
   /* In-place QuickSort algorithm.
    */
   var third_index = 0;
   while (true) {
     // Insertion sort is faster for short arrays.
     if (to - from <= 10) {
-      Array.prototype.sort.insertionSort(a, from, to, comparefn);
+      Array.prototype.sort.insertionSort_(a, from, to, comparefn);
       return;
     }
     if (to - from > 1000) {
-      third_index = Array.prototype.sort.getThirdIndex(a, from, to, comparefn);
+      third_index = Array.prototype.sort.getThirdIndex_(a, from, to, comparefn);
     } else {
       third_index = from + ((to - from) >> 1);
     }
@@ -778,15 +778,15 @@ Array.prototype.sort.quickSort = function quickSort(a, from, to, comparefn) {
       }
     }
     if (to - high_start < low_end - from) {
-      quickSort(a, high_start, to, comparefn);
+      quicksort_(a, high_start, to, comparefn);
       to = low_end;
     } else {
-      quickSort(a, from, low_end, comparefn);
+      quicksort_(a, from, low_end, comparefn);
       from = high_start;
     }
   }
 };
-Object.defineProperty(Array.prototype.sort, 'quickSort', {enumerable: false});
+Object.defineProperty(Array.prototype.sort, 'quicksort_', {enumerable: false});
 
 Array.prototype.toLocaleString = function() {
   var out = [];


### PR DESCRIPTION
Two unrelated improvements to `Array.prototype` methods:

* Simplify the `Array.prototype.join` builtin native function to avoid needing a state machine.  (This is a re-run of PR #434.)
* Suffix the helper methods on `Array.prototype.sort` with `_` to indicate they are private.
