### PR TITLE
Have nginx add Forwarded: header

### DIFF
--- a/etc/cc-localhost.conf
+++ b/etc/cc-localhost.conf
@@ -8,7 +8,9 @@
 # Configuration applying to all servers.
 error_page 502 503 504 =503 /static/503.html;
 
+# Configuration applying to all proxy forwarding.
 proxy_set_header Host $http_host;
+proxy_set_header Forwarded $proxy_add_forwarded;  # See below.
 proxy_pass_header Server;
 proxy_next_upstream_tries 1;
 proxy_max_temp_file_size 0;
@@ -48,4 +50,36 @@ server {
     # Proxy to mobwrite_server.py port 7783.
     proxy_pass http://127.0.0.1:7783/mobwrite;
   }
+}
+
+# Configuration for generating Forwarded: header, based on example from
+# https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/
+#
+# Conceal the IP address of incoming connections by default, as it is
+# PII and we try to avoid giving users any chance to get their hands
+# on each other's PII.  To enable inclusion of actual IP addresses of
+# incoming connections in the Forwarded header, uncomment the first
+# two matchers below.
+map $remote_addr $proxy_forwarded_for {
+    # IPv4 addresses can be sent as-is.
+#    ~^[0-9.]+$          "for=$remote_addr"
+
+    # IPv6 addresses need to be bracketed and quoted.
+#    ~^[0-9A-Fa-f:.]+$   "for=\"[$remote_addr]\"";
+
+    # Unix domain socket names cannot be represented in RFC 7239 syntax.
+    default             "for=unknown";
+}
+
+# Append host and proto.
+map $proxy_forwarded_for $proxy_forwarded_elem {
+    default "$proxy_forwarded_for;host=$http_host;proto=$scheme";
+}
+
+map $http_forwarded $proxy_add_forwarded {
+    # If the incoming Forwarded header is syntactically valid, append to it.
+    "~^(,[ \\t]*)*([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?(;([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?)*([ \\t]*,([ \\t]*([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?(;([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?)*)?)*$" "$http_forwarded, $proxy_forwarded_elem";
+
+    # Otherwise, replace it.
+    default "$proxy_forwarded_elem";
 }

--- a/etc/cc-onedomain.conf
+++ b/etc/cc-onedomain.conf
@@ -4,7 +4,9 @@
 # Configuration applying to all servers.
 error_page 502 503 504 =503 /static/503.html;
 
+# Configuration applying to all proxy forwarding.
 proxy_set_header Host $http_host;
+proxy_set_header Forwarded $proxy_add_forwarded;  # See below.
 proxy_pass_header Server;
 proxy_next_upstream_tries 1;
 proxy_max_temp_file_size 0;
@@ -80,4 +82,36 @@ server {
     # Proxy to mobwrite_server.py port 7783.
     proxy_pass http://127.0.0.1:7783/mobwrite;
   }
+}
+
+# Configuration for generating Forwarded: header, based on example from
+# https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/
+#
+# Conceal the IP address of incoming connections by default, as it is
+# PII and we try to avoid giving users any chance to get their hands
+# on each other's PII.  To enable inclusion of actual IP addresses of
+# incoming connections in the Forwarded header, uncomment the first
+# two matchers below.
+map $remote_addr $proxy_forwarded_for {
+    # IPv4 addresses can be sent as-is.
+#    ~^[0-9.]+$          "for=$remote_addr"
+
+    # IPv6 addresses need to be bracketed and quoted.
+#    ~^[0-9A-Fa-f:.]+$   "for=\"[$remote_addr]\"";
+
+    # Unix domain socket names cannot be represented in RFC 7239 syntax.
+    default             "for=unknown";
+}
+
+# Append host and proto.
+map $proxy_forwarded_for $proxy_forwarded_elem {
+    default "$proxy_forwarded_for;host=$http_host;proto=$scheme";
+}
+
+map $http_forwarded $proxy_add_forwarded {
+    # If the incoming Forwarded header is syntactically valid, append to it.
+    "~^(,[ \\t]*)*([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?(;([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?)*([ \\t]*,([ \\t]*([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?(;([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?)*)?)*$" "$http_forwarded, $proxy_forwarded_elem";
+
+    # Otherwise, replace it.
+    default "$proxy_forwarded_elem";
 }

--- a/etc/cc-subdomain.conf
+++ b/etc/cc-subdomain.conf
@@ -6,7 +6,9 @@
 # E.g.: static.example.codecity.world
 error_page 502 503 504 =503 https://static.INSTANCENAME/503.html;
 
+# Configuration applying to all proxy forwarding.
 proxy_set_header Host $http_host;
+proxy_set_header Forwarded $proxy_add_forwarded;  # See below.
 proxy_pass_header Server;
 proxy_next_upstream_tries 1;
 proxy_max_temp_file_size 0;
@@ -117,3 +119,36 @@ server {
     root /home/codecity/CodeCity/static;
   }
 }
+
+# Configuration for generating Forwarded: header, based on example from
+# https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/
+#
+# Conceal the IP address of incoming connections by default, as it is
+# PII and we try to avoid giving users any chance to get their hands
+# on each other's PII.  To enable inclusion of actual IP addresses of
+# incoming connections in the Forwarded header, uncomment the first
+# two matchers below.
+map $remote_addr $proxy_forwarded_for {
+    # IPv4 addresses can be sent as-is.
+#    ~^[0-9.]+$          "for=$remote_addr"
+
+    # IPv6 addresses need to be bracketed and quoted.
+#    ~^[0-9A-Fa-f:.]+$   "for=\"[$remote_addr]\"";
+
+    # Unix domain socket names cannot be represented in RFC 7239 syntax.
+    default             "for=unknown";
+}
+
+# Append host and proto.
+map $proxy_forwarded_for $proxy_forwarded_elem {
+    default "$proxy_forwarded_for;host=$http_host;proto=$scheme";
+}
+
+map $http_forwarded $proxy_add_forwarded {
+    # If the incoming Forwarded header is syntactically valid, append to it.
+    "~^(,[ \\t]*)*([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?(;([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?)*([ \\t]*,([ \\t]*([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?(;([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?)*)?)*$" "$http_forwarded, $proxy_forwarded_elem";
+
+    # Otherwise, replace it.
+    default "$proxy_forwarded_elem";
+}
+


### PR DESCRIPTION
We already have nginx modify the Host: header of the outgoing proxied request to match the incoming one, so this mainly gets us the protocol (http vs. https) and optionally the originating IP address.

I considered putting the lengthy common bit in a `cc-common.conf` and `includ`ing it from each of the individual config files, but only one of the three actually ends up in `/etc/nginx/...`—and then there's the issue of working out where to include it from: the common part should probably normally live in `/etc/nginx/snippets/` which means a more complicated installation, but when using the `nginx-dev` script you really want to use the copy in `CodeCity/etc/` directly, which means having to do more rewrites of `cc-localhost.conf` when the script prepares it for use.  My feeling is that we might want to move in that direction in the future but for now copy-and-paste is probably the simplest option.  Other views welcome.