### PR TITLE
Fix JSON.stringify handling of functions, non-enumerable properties

### DIFF
--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -2690,6 +2690,15 @@ tests.JsonStringify = function () {
       '"null":null,"object":{"obj":{},"arr":[]},"array":[{},[]]}';
   console.assert(JSON.stringify(obj) === str, 'JSON.stringify basic');
 
+  console.assert(JSON.stringify(function(){}) === undefined,
+      'JSON.stringify(function(){})');
+
+  console.assert(JSON.stringify([function(){}]) === '[null]',
+      'JSON.stringify([function(){}])');
+
+  console.assert(JSON.stringify({f: function(){}}) === '{}',
+      'JSON.stringify({f: function(){}})');
+
   str = '{"string":"foo","number":42}';
   console.assert(JSON.stringify(obj, ['string', 'number']) === str,
       'JSON.stringify filter');
@@ -2701,6 +2710,21 @@ tests.JsonStringify = function () {
   str = '{\n--"string": "foo",\n--"number": 42\n}';
   console.assert(JSON.stringify(obj, ['string', 'number'], '--') === str,
       'JSON.stringify pretty string');
+
+  obj = {e: 'enumerable', ne: 'nonenumerable'};
+  Object.defineProperty(obj, 'ne', {enumerable: false});
+  console.assert(JSON.stringify(obj) === '{"e":"enumerable"}',
+      'JSON.stringify nonenumerable');
+
+
+  obj = {};
+  obj.circular = obj;
+  try {
+    JSON.stringify(obj);
+    console.assert(false, "JSON.stringify didn't throw");
+  } catch (e) {
+    console.assert(e.name === 'TypeError', 'JSON.stringify wrong error');
+  }
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -2716,6 +2716,8 @@ tests.JsonStringify = function () {
   console.assert(JSON.stringify(obj) === '{"e":"enumerable"}',
       'JSON.stringify nonenumerable');
 
+  console.assert(JSON.stringify(Object.create({foo: 'bar'})) === '{}',
+      'JSON.stringify inherited');
 
   obj = {};
   obj.circular = obj;

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -2692,6 +2692,11 @@ module.exports = [
     `,
     expected: '{"e":"enumerable"}' },
 
+  { name: 'JSON.stringify inherited', src: `
+    JSON.stringify(Object.create({foo: 'bar'}));
+    `,
+    expected: '{}' },
+
   { name: 'JSON.stringify circular', src: `
     var obj = {};
     obj.circular = obj;

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -2646,6 +2646,21 @@ module.exports = [
     expected: '{"string":"foo","number":42,"true":true,"false":false,' +
         '"null":null,"object":{"obj":{},"arr":[]},"array":[{},[]]}' },
 
+  { name: 'JSON.stringify(function(){})', src: `
+    JSON.stringify(function(){});
+    `,
+    expected: undefined },
+
+  { name: 'JSON.stringify([function(){}])', src: `
+    JSON.stringify([function(){}]);
+    `,
+    expected: "[null]" },
+
+  { name: 'JSON.stringify({f: function(){}})', src: `
+    JSON.stringify({f: function(){}});
+    `,
+    expected: "{}" },
+
   { name: 'JSON.stringify filter', src: `
     JSON.stringify({
         string: 'foo', number: 42, true: true, false: false, null: null,
@@ -2669,6 +2684,24 @@ module.exports = [
         ['string', 'number'], '--');
     `,
     expected: '{\n--"string": "foo",\n--"number": 42\n}' },
+
+  { name: 'JSON.stringify nonenumerable', src: `
+    var obj = {e: 'enumerable', ne: 'nonenumerable'};
+    Object.defineProperty(obj, 'ne', {enumerable: false});
+    JSON.stringify(obj);
+    `,
+    expected: '{"e":"enumerable"}' },
+
+  { name: 'JSON.stringify circular', src: `
+    var obj = {};
+    obj.circular = obj;
+    try {
+      JSON.stringify(obj);
+    } catch (e) {
+      e.name;
+    }
+    `,
+    expected: 'TypeError' },
 
   /////////////////////////////////////////////////////////////////////////////
   // Other built-in functions


### PR DESCRIPTION
Fix two bugs in `JSON.stringify`:

* Functions should stringify as `undefined` (if passed directly to `.stringify`), as `null` (if in an array) or be ignored (if they are the value of a property).  Previously, they were treated as ordinary objects.

* Nonenumerable properties should be ignored.

Fix these issues by having `.pseudoToNative` return `undefined` if passed a function object, and transcribe property attributes onto the native object.

Also add test for `JSON.stringify` ignoring inherited properties.