### PR TITLE
Fix repl output after .pseudoToNative changes

### DIFF
--- a/server/repl
+++ b/server/repl
@@ -55,7 +55,12 @@ rl.on('line', function(line) {
       return;
     }
     intrp.run();
-    console.log(intrp.pseudoToNative(thread.value));
+    const value = thread.value;
+    if (value instanceof intrp.Function) {
+      console.log(value.toString());
+    } else {
+      console.log('%o', intrp.pseudoToNative(thread.value));
+    }
   } finally {
     rl.prompt();
   }


### PR DESCRIPTION
In PR #450 `Interpreter.prototype.pseudoToNative` was modified to make
the `JSON.stringify` builtin behave more correctly (per ES5.1 spec).

Unfortunately this meant that in `repl` any expression that yielded
a function would be shown as having value undefined.

Fix `repl` so that if the expression evaluates to a function that
function is printed.  (It will still hide methods, as `JSON.stringify`
does.  But this is better than before, and perfecting `repl` is not
a priority at the moment.)