### PR TITLE
Implement a login service backend

### DIFF
--- a/core/core_10_base.js
+++ b/core/core_10_base.js
@@ -58,6 +58,7 @@ $.system.onStartup = function onStartup() {
    * listening sockets, etc.)
    */
   // Listen on various sockets.
+  try {$.system.connectionListen(7776, $.servers.login.connection, 100);} catch(e) {}
   try {$.system.connectionListen(7777, $.servers.telnet.connection, 100);} catch(e) {}
   try {$.system.connectionListen(7780, $.servers.http.connection, 100);} catch(e) {}
   try {$.system.connectionListen(9999, $.servers.eval.connection);} catch(e) {}
@@ -74,7 +75,7 @@ $.system.onStartup = function onStartup() {
   $.Selector.db.populate();
   $.system.log('Startup: Selector reverse-lookup DB rebuilt.');
 };
-Object.setOwnerOf($.system.onStartup, $.physicals.Maximilian);
+Object.setOwnerOf($.system.onStartup, $.physicals.Neil);
 Object.setOwnerOf($.system.onStartup.prototype, $.physicals.Maximilian);
 
 var user = function user() {

--- a/core/core_22_$.connection.js
+++ b/core/core_22_$.connection.js
@@ -49,6 +49,7 @@ Object.setOwnerOf($.connection.onReceiveLine, $.physicals.Maximilian);
 $.connection.onEnd = function onEnd() {
   this.connected = false;
   this.disconnectTime = Date.now();
+  this.close();
 };
 Object.setOwnerOf($.connection.onEnd, $.physicals.Maximilian);
 $.connection.write = function write(text) {

--- a/core/core_23_$.servers.http.js
+++ b/core/core_23_$.servers.http.js
@@ -896,6 +896,7 @@ $.servers.http.onRequest = function onRequest(connection) {
       response.sendError(500, e);
     }
   } finally {
+    suspend();
     connection.close();
   }
 };

--- a/core/core_25_$.userDatabase.js
+++ b/core/core_25_$.userDatabase.js
@@ -39,10 +39,13 @@ $.userDatabase.get = function get(id) {
 Object.setOwnerOf($.userDatabase.get, $.physicals.Neil);
 Object.setOwnerOf($.userDatabase.get.prototype, $.physicals.Maximilian);
 $.userDatabase.set = function set(id, user) {
+  if (!$.user.isPrototypeOf(user)) {
+    throw new TypeError('userDatabase only accepts $.user values');
+  }
   var hash = $.utils.string.hash('md5', this.salt_ + id);
   this.byMd5[hash] = user;
 };
-Object.setOwnerOf($.userDatabase.set, $.physicals.Neil);
+Object.setOwnerOf($.userDatabase.set, $.physicals.Maximilian);
 Object.setOwnerOf($.userDatabase.set.prototype, $.physicals.Maximilian);
 $.userDatabase.validate = function validate() {
   var table = this.byMd5

--- a/core/core_34_$.servers.login.js
+++ b/core/core_34_$.servers.login.js
@@ -27,7 +27,6 @@ $.servers.login = {};
 Object.setOwnerOf($.servers.login, $.physicals.Neil);
 $.servers.login.connection = (new 'Object.create')($.connection);
 $.servers.login.connection.onReceiveLine = function onReceiveLine(line) {
-  $.system.log('login service backend got: ' + $.utils.code.toSource(line));
   line = line.trim();
   try {
     var loginData = JSON.parse(line);

--- a/core/core_34_$.servers.login.js
+++ b/core/core_34_$.servers.login.js
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Login service backend server for Code City.
+ */
+
+//////////////////////////////////////////////////////////////////////
+// AUTO-GENERATED CODE FROM DUMP.  EDIT WITH CAUTION!
+//////////////////////////////////////////////////////////////////////
+
+$.servers.login = {};
+Object.setOwnerOf($.servers.login, $.physicals.Neil);
+$.servers.login.connection = (new 'Object.create')($.connection);
+$.servers.login.connection.onReceiveLine = function onReceiveLine(line) {
+  $.system.log('login service backend got: ' + $.utils.code.toSource(line));
+  line = line.trim();
+  try {
+    var loginData = JSON.parse(line);
+    var cookie = $.servers.login.getCookie(loginData);
+    this.write(cookie);
+  } catch (err) {
+    // Just log error.
+    suspend();
+    $.system.log('$.servers.login: ' + String(err));
+  } finally {
+    suspend();
+    this.close();
+  }
+};
+Object.setOwnerOf($.servers.login.connection.onReceiveLine, $.physicals.Maximilian);
+Object.setOwnerOf($.servers.login.connection.onReceiveLine.prototype, $.physicals.Neil);
+$.servers.login.getUser = function getUser(id) {
+  /* Get the $.user for the given id, or create one if none exists.
+   *
+   * Arguments:
+   * - id: string - the ID cookie for the given user.
+   * Returns: a $.user
+   */
+  var user = $.userDatabase.get(id);
+  if (user) return user;
+
+  // Create new $.user.
+  user = Object.create($.user);
+  user.setName('Guest', /*tryAlternative:*/ true);
+  $.userDatabase.set(id, user);
+  /*
+  (function() {
+    setPerms(user);
+		var home = Object.create($.room);
+	  home.setName(user.name + "'s room", true);
+	  home.description = 'A quiet place for ' + user.name + ' to work.';
+	  user.home = home;
+	  user.moveTo(home);
+  })();
+  */
+  return user;
+};
+Object.setOwnerOf($.servers.login.getUser, $.physicals.Maximilian);
+Object.setOwnerOf($.servers.login.getUser.prototype, $.physicals.Maximilian);
+$.servers.login.getCookie = function getCookie(loginData) {
+  /* Get the ID cookie for the given loginData.
+   *
+   * Arguments:
+   * - loginData: !Object - the loginData object from loginServer.
+   * Returns: string - the ID cookie to set.  Empty string denotes
+   *     invalid login.
+   */
+  var id = loginData.id;
+  if (typeof(id) !== 'string') {
+    return '';
+  } else if ($.userDatabase.get(id)) {  // User already exists.
+    return id;
+  } else {  // Create new user object.
+    var name = loginData.given_name || loginData.name ||
+        loginData.email && loginData.email.replace(/@.*$/, '');
+    this.createUser(id, name);
+    return id;
+  }
+};
+Object.setOwnerOf($.servers.login.getCookie, $.physicals.Maximilian);
+Object.setOwnerOf($.servers.login.getCookie.prototype, $.physicals.Maximilian);
+$.servers.login.createUser = function createUser(id, name) {
+  /* Get the $.user for the given id, or create one if none exists.
+   *
+   * Arguments:
+   * - id: string - the ID cookie for the given user.
+   * - name: string - the name for the new user.
+   * Returns: Object - the new $.user object
+   */
+  if ($.userDatabase.get(id)) throw new TypeError('user already exists');
+
+  // Create new $.user.
+  user = Object.create($.user);
+  user.setName(name || 'Guest', /*tryAlternative:*/ true);
+  $.userDatabase.set(id, user);
+  /*
+  (function() {
+    setPerms(user);
+		var home = Object.create($.room);
+	  home.setName(user.name + "'s room", true);
+	  home.description = 'A quiet place for ' + user.name + ' to work.';
+	  user.home = home;
+	  user.moveTo(home);
+  })();
+  */
+  return user;
+};
+Object.setOwnerOf($.servers.login.createUser, $.physicals.Maximilian);
+Object.setOwnerOf($.servers.login.createUser.prototype, $.physicals.Maximilian);
+

--- a/core/dump_spec.json
+++ b/core/dump_spec.json
@@ -335,6 +335,15 @@
       {"path": "$.physicals['Container prototype']", "do": "DONE"}
     ]
   }, {
+    "filename": "core_34_$.servers.login.js",
+    "headerSubs": {
+      "<YEAR>": "2021",
+      "<OVERVIEW>": "Login service backend server for Code City."
+    },
+    "contents": [
+      "$.servers.login"
+    ]
+  }, {
     "filename": "core_34_$.servers.telnet.js",
     "headerSubs": {
       "<YEAR>": "2017",
@@ -574,6 +583,8 @@
       "$.room",
       "$.thing",
       "$.container",
+
+      "$.servers.login",
 
       "$.servers.telnet",
 

--- a/database/core_34_$.servers.login.js
+++ b/database/core_34_$.servers.login.js
@@ -1,0 +1,1 @@
+../core/core_34_$.servers.login.js

--- a/login/loginServer
+++ b/login/loginServer
@@ -28,6 +28,7 @@ const forwardedParse = require('forwarded-parse');
 const fs = require('fs').promises;
 const {google} = require('googleapis');
 const http = require('http');
+const net = require('net');
 const {URL, format: urlFormat} = require('url');
 
 const oauth2Api = google.oauth2('v2');
@@ -56,9 +57,25 @@ const DEFAULT_CFG = {
   // Random salt for login IDs.
   salt: 'zzzzzzzzzzzzzzzz',
   // Regexp on email addresses that must pass to allow access.
-  emailRegexp: '.*'
+  emailRegexp: '.*',
+  // Port number for the login service backend.
+  backendPort: 7776,
+  /* List of fields, from data object returned by
+   * oauth2Api.userinfo.v2.me.get, to pass along in the request the
+   * login service backend.
+   *
+   * Available fieldnames, and the types and meanings of their values:
+   * - id: string - the user's OAuth (GAIA) ID as a numeric string.
+   * - email: string - the user's email address.
+   * - verified_email: boolean - has the user's email address been verified?
+   * - name: string - the user's full name.
+   * - given_name: string - the user's given name.
+   * - family_name: string - the user's family name.
+   * - picture: string - URL pointing to the user's profile picture.
+   * - hd: string - the hosted domain, for GSuite accounts.
+   */
+  backendFields: ['id']
 };
-
 
 /**
  * Serve an error to the given ServerResult.  Also log information
@@ -71,7 +88,7 @@ const DEFAULT_CFG = {
  */
 function sendError(request, response, statusCode, message) {
   console.log('%s %s (Host: %s): %d %s', request.method,
-              request.url.replace(/=[^&]*(?=&|$)/g, '=...'),
+              request.url.replace(/=[^&]*(?=&|$)/g, '=…'),
               request.headers.host, statusCode, message);
   response.writeHead(statusCode).end(message);
 }
@@ -100,6 +117,35 @@ async function serveFile(request, response, filename, subs) {
   response.statusCode = 200;
   response.setHeader('Content-Type', 'text/html');
   response.end(data);
+}
+
+/**
+ * Send a string to the login service backend and return any data
+ * received in response.
+ * @param {string} query Data string to send to backend.
+ * @return {!Promise<string>} a promise yeilding the data received.
+ */
+async function pingBackend(query) {
+  let result = '';
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({port: CFG.backendPort});
+    socket.on('connect', () => {
+      console.log('Backend: sent %o', query);
+      socket.end(query);
+    });
+    socket.on('error', (error) => {
+      socket.destroy();
+      reject(error);
+    });
+    socket.on('data', (data) => {
+      console.log('Backend: received %o', String(data));
+      result += String(data);
+    });
+    socket.on('end', () => {
+      console.log('Backend: closed');
+      resolve(result);
+    });
+  });
 }
 
 /**
@@ -164,7 +210,7 @@ async function handleRequest(request, response) {
     return;
   }
 
-  // Handle the result of a login.
+  // Handle the result of an OAuth login.
   let tokens;
   try {
     ({tokens} = await oauth2Client.getToken(code));
@@ -182,17 +228,48 @@ async function handleRequest(request, response) {
     sendError(request, response, 500, `Google Userinfo fail: ${err}`);
     return;
   }
-  // Convert the Google ID into one unique for Code City.
-  const id = crypto.createHash('sha512')
-      .update(CFG.salt + data.id).digest('hex');
-  const emailRegexp = new RegExp(CFG.emailRegexp || '.*');
-  // FYI: If present, data.hd contains the GSfE domain.
-  // E.g. 'students.gissv.org', or 'sjsu.edu'.
-  // We aren't using it now, but this might be used to filter users.
 
   // Check email address is allowed.
+  const emailRegexp = new RegExp(CFG.emailRegexp || '.*');
   if (!emailRegexp.test(data.email)) {
     sendError(request, response, 403, `Login denied for ${data.email}`);
+    return;
+  }
+  // FYI: If present, data.hd contains the GSfE domai,
+  // e.g. 'students.gissv.org', or 'sjsu.edu'.  We aren't using it
+  // now, but this might be used to filter users.
+
+  // Convert the OAuth (GAIA) ID into one unique for Code City.  Use
+  // CFG.salt to salt the sha512hash.  If .salt === '', then .id will
+  // still be hashed but not salted.
+  // TODO(cpcallen): it would be more secure to append salt to id.
+  if (('id' in data) && CFG.salt !== undefined) {
+    data.id = crypto.createHash('sha512')
+        .update(CFG.salt + data.id).digest('hex');
+  }
+
+  // Contact login service backend if configured.
+  let cookie;
+  if (CFG.backendPort) {
+    // Construct object to be passed to login service backend.
+    const loginData = {};
+    for (const name of CFG.backendFields || ['id']) {
+      if (name in data) loginData[name] = data[name];
+    }
+
+    // Ping the login service backend.
+    try {
+      cookie = await pingBackend(JSON.stringify(loginData) + '\n');
+    } catch (err) {
+      sendError(request, response, 500, `Login service backend fail: ${err}`);
+      return;
+    }
+  } else {
+    // Just use the (probably salted and hashed) id value like we used to.
+    cookie = data.id;
+  }
+  if (!cookie) {
+    sendError('Login service backend did not return a valid cookie');
     return;
   }
 
@@ -206,11 +283,11 @@ async function handleRequest(request, response) {
   const redirectUrl = url.searchParams.get('state');
 
   response.writeHead(302, {  // Temporary redirect.
-    'Set-Cookie': `ID=${id}; HttpOnly; ${domain}Path=/`,
+    'Set-Cookie': `ID=${cookie}; HttpOnly; ${domain}Path=/`,
     'Location': redirectUrl,
   });
   response.end('Login OK.  Redirecting.');
-  console.log('Accepted xxxx' + id.substring(id.length - 4));
+  console.log('Accepted xxxx' + cookie.substring(cookie.length - 4));
 }
 
 /**

--- a/login/loginServer
+++ b/login/loginServer
@@ -54,8 +54,6 @@ const DEFAULT_CFG = {
   clientSecret: 'yyyyyyyyyyyyyyyyyyyyyyyy',
   // Root domain.
   cookieDomain: 'example.codecity.world',
-  // Random salt for login IDs.
-  salt: 'zzzzzzzzzzzzzzzz',
   // Regexp on email addresses that must pass to allow access.
   emailRegexp: '.*',
   // Port number for the login service backend.
@@ -66,6 +64,8 @@ const DEFAULT_CFG = {
    *
    * Available fieldnames, and the types and meanings of their values:
    * - id: string - the user's OAuth (GAIA) ID as a numeric string.
+   *   If salt is set (below), the .id will be salted and hashed with
+   *   sha512 before being sent to the login backend service.
    * - email: string - the user's email address.
    * - verified_email: boolean - has the user's email address been verified?
    * - name: string - the user's full name.
@@ -74,7 +74,12 @@ const DEFAULT_CFG = {
    * - picture: string - URL pointing to the user's profile picture.
    * - hd: string - the hosted domain, for GSuite accounts.
    */
-  backendFields: ['id']
+  backendFields: ['id'],
+  /* Random salt for OAuth IDs.  If set to '' the .id field received
+   * from the Oauth server will be hashed but not salted. If set to 
+   * undefined (or not set) the .id wil be sent plaintext.
+   */
+  salt: 'zzzzzzzzzzzzzzzz'
 };
 
 /**
@@ -305,7 +310,7 @@ async function readConfigFile(filename) {
     await fs.writeFile(filename, data, 'utf8');
   }
   CFG = JSON.parse(data);
-  if (!CFG.salt || CFG.salt === DEFAULT_CFG.salt) {
+  if (CFG.salt === DEFAULT_CFG.salt) {
     throw Error(
         `Configuration file ${filename} not configured.  ` +
         'Please edit this file.');

--- a/login/loginServer
+++ b/login/loginServer
@@ -135,7 +135,6 @@ async function pingBackend(query) {
   return new Promise((resolve, reject) => {
     const socket = net.createConnection({port: CFG.backendPort});
     socket.on('connect', () => {
-      console.log('Backend: sent %o', query);
       socket.end(query);
     });
     socket.on('error', (error) => {
@@ -143,11 +142,9 @@ async function pingBackend(query) {
       reject(error);
     });
     socket.on('data', (data) => {
-      console.log('Backend: received %o', String(data));
       result += String(data);
     });
     socket.on('end', () => {
-      console.log('Backend: closed');
       resolve(result);
     });
   });


### PR DESCRIPTION
Have loginServer send some of the data it got from the OAuth login to the database as a JSON string via a new server, `$.servers.login`, listening on port 7776, which will return a string to use as the ID cookie.

Also enable half-open sockets, so that `loginServer` (or indeed a web browser) can close its end of the connection as soon as it is done sending a query without preventing the responding server from sending data back.