### PR TITLE
Fix network-related test failures

### DIFF
--- a/server/externs/events/events.js
+++ b/server/externs/events/events.js
@@ -24,15 +24,25 @@
 /** @const */
 var events = {};
 
+/** @type {symbol} */
+events.errorMonitor;
+
 /** @constructor */
 events.EventEmitter = function() {};
 
 /**
- * @param {string} event
+ * @param {string|symbol} event
  * @param {function(...)} listener
  * @return {events.EventEmitter}
  */
 events.EventEmitter.prototype.on = function(event, listener) {};
+
+/**
+ * @param {string|symbol} event
+ * @param {function(...)} listener
+ * @return {events.EventEmitter}
+ */
+events.EventEmitter.prototype.removeListener = function(event, listener) {};
 
 /**
  * @param {string} event

--- a/server/externs/net/net.js
+++ b/server/externs/net/net.js
@@ -27,16 +27,28 @@ var events = require('events');
 var net = {};
 
 /**
+ * @typedef {{allowHalfOpen: ?boolean}}
+ */
+var createOptions;
+
+/**
+ * @param {(createOptions|function(...))=} options
+ * @param {function(...)=} connectionListener
+ * @return {net.Server}
+ */
+net.createServer = function(options, connectionListener) {};
+
+/**
  * @typedef {{port: (number|undefined),
  *            host: (string|undefined),
  *            localAddress: (string|undefined),
  *            path: (string|undefined),
  *            allowHalfOpen: (boolean|undefined)}}
  */
-net.ConnectOptions;
+var connectOptions;
 
 /**
- * @param {net.ConnectOptions|number|string} arg1
+ * @param {connectOptions|number|string} arg1
  * @param {(function(...)|string)=} arg2
  * @param {function(...)=} arg3
  * @return {!net.Socket}
@@ -48,8 +60,9 @@ net.createConnection = function(arg1, arg2, arg3) {};
 
 /**
  * @constructor
+ * @param {createOptions=} options
  */
-net.Server = function() {};
+net.Server = function(options) {};
 
 /**
  * @return {{port: number, family: string, address: string}}

--- a/server/externs/net/net.js
+++ b/server/externs/net/net.js
@@ -61,6 +61,7 @@ net.createConnection = function(arg1, arg2, arg3) {};
 /**
  * @constructor
  * @param {createOptions=} options
+ * @extends {events.EventEmitter}
  */
 net.Server = function(options) {};
 
@@ -84,13 +85,6 @@ net.Server.prototype.close = function(callback) {};
  * @return {void}
  */
 net.Server.prototype.listen = function(port, host, backlog, callback) {};
-
-/**
- * @param {string} event
- * @param {function(...)} listener
- * @return {net.Server}
- */
-net.Server.prototype.on = function(event, listener) {};
 
 ///////////////////////////////////////////////////////////////////////////////
 // net.Socket

--- a/server/serialize.js
+++ b/server/serialize.js
@@ -168,14 +168,14 @@ Serializer.deserialize = function(json, intrp) {
       var nonConfigurable = jsonObj['nonConfigurable'] || [];
       var nonEnumerable = jsonObj['nonEnumerable'] || [];
       var nonWritable = jsonObj['nonWritable'] || [];
-      var names = Object.getOwnPropertyNames(props);
-      for (var j = 0; j < names.length; j++) {
-        var name = names[j];
-        Object.defineProperty(obj, name,
-            {configurable: !nonConfigurable.includes(name),
-             enumerable: !nonEnumerable.includes(name),
-             writable: !nonWritable.includes(name),
-             value: decodeValue(props[name])});
+      var keys = Object.getOwnPropertyNames(props);
+      for (var j = 0; j < keys.length; j++) {
+        var key = keys[j];
+        Object.defineProperty(obj, key,
+            {configurable: !nonConfigurable.includes(key),
+             enumerable: !nonEnumerable.includes(key),
+             writable: !nonWritable.includes(key),
+             value: decodeValue(props[key])});
       }
     }
     // Repopulate sets.
@@ -366,25 +366,25 @@ Serializer.serialize = function(intrp) {
     var nonConfigurable = [];
     var nonEnumerable = [];
     var nonWritable = [];
-    var names = Object.getOwnPropertyNames(obj);
-    for (var j = 0; j < names.length; j++) {
-      var name = names[j];
-      if (obj === intrp && exclude.includes(name)) {
+    var keys = Object.getOwnPropertyNames(obj);
+    for (var j = 0; j < keys.length; j++) {
+      var key = keys[j];
+      if (obj === intrp && exclude.includes(key)) {
         continue;
       }
-      props[name] = encodeValue(obj[name]);
-      var descriptor = Object.getOwnPropertyDescriptor(obj, name);
+      props[key] = encodeValue(obj[key]);
+      var descriptor = Object.getOwnPropertyDescriptor(obj, key);
       if (!descriptor.configurable) {
-        nonConfigurable.push(name);
+        nonConfigurable.push(key);
       }
       if (!descriptor.enumerable) {
-        nonEnumerable.push(name);
+        nonEnumerable.push(key);
       }
       if (!descriptor.writable) {
-        nonWritable.push(name);
+        nonWritable.push(key);
       }
     }
-    if (names.length) {
+    if (keys.length) {
       jsonObj['props'] = props;
     }
     if (nonConfigurable.length) {
@@ -446,12 +446,12 @@ Serializer.objectHunt_ = function(node, seen, excludeTypes, exclude) {
         !(obj instanceof IterableWeakSet) &&
         !(obj instanceof RegExp) &&
         !(obj instanceof Set)) {
-      var names = Object.getOwnPropertyNames(obj);
-      for (var i = 0; i < names.length; i++) {
-        var name = names[i];
-        if (!exclude || !exclude.includes(name)) {
+      var keys = Object.getOwnPropertyNames(obj);
+      for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        if (!exclude || !exclude.includes(key)) {
           // Don't pass exclude; it's only for top-level property keys.
-          Serializer.objectHunt_(obj[name], seen, excludeTypes);
+          Serializer.objectHunt_(obj[key], seen, excludeTypes);
         }
       }
     }

--- a/server/serialize.js
+++ b/server/serialize.js
@@ -240,12 +240,15 @@ Serializer.deserialize = function(json, intrp) {
   // Second pass: Populate properties for every object.
   for (var i = 0; i < json.length; i++) {
     var jsonObj = json[i];
+    var tag = jsonObj['type'];
+    var typeInfo = config.byTag[tag];
     var obj = objectList[i];
     // Set prototype, if specified.
     if (jsonObj['proto']) {
       Object.setPrototypeOf(obj, decodeValue(jsonObj['proto']));
     }
     // Repopulate properties.
+    var prune = (typeInfo && typeInfo.prune) || [];
     var props = jsonObj['props'];
     if (props) {
       var nonConfigurable = jsonObj['nonConfigurable'] || [];
@@ -254,6 +257,7 @@ Serializer.deserialize = function(json, intrp) {
       var keys = Object.getOwnPropertyNames(props);
       for (var j = 0; j < keys.length; j++) {
         var key = keys[j];
+        if (prune.includes(key)) continue;
         Object.defineProperty(obj, key,
             {configurable: !nonConfigurable.includes(key),
              enumerable: !nonEnumerable.includes(key),

--- a/server/serialize.js
+++ b/server/serialize.js
@@ -56,7 +56,7 @@ var TypeInfo;
 var Config;
 
 /**
- * Create a configuration object for serializing or desieralizing na
+ * Create a configuration object for serializing or desieralizing a
  * particular Interpreter instance.
  *
  * @param {!Interpreter} intrp The interpreter instance being serialized

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -1371,6 +1371,7 @@ exports.testNetworking = async function(t) {
         data += d;
       };
       conn.onEnd = function() {
+        CC.connectionClose(this);
         CC.connectionUnlisten(8888);
         resolve(data);
       };

--- a/server/tests/serialize_test.js
+++ b/server/tests/serialize_test.js
@@ -493,6 +493,7 @@ exports.testRoundtripAsync = async function(t) {
         data += d;
       };
       conn.onEnd = function() {
+        CC.connectionClose(this);
         CC.connectionUnlisten(8888);
         resolve(data);
       };


### PR DESCRIPTION
The goal of this PR is to clean up compile and test failures.  There are quite a few of the latter, so here we concentrate on the ones which were causing the tests to hang.  Specifically:

* Fix compile errors that had been caused by enabling `allowHalfOpen`.
* Fix test hangs due to enabling `allowHalfOpen`.
* Some additional tidying of network-related tests.
* Attempt to add two seemingly-innocuous tests of interaction between networking code and the `start`, `stop` and `pause` methods on `Interpreter`, but discover that there are some async-related "race conditions" (not actually indeterminate—just unexpected) that cause test crashes, revealing the present network code is even more fragile than previously believed.
* Substantially refactor `Interpreter.prototype.Server` to fix this, but realise that `Serializer` now mungs `Server.server_`.
* Take a diversion and make several improvements to `Serializer`.
* Finally check in the refactored `Server` code and the innocuous-looking tests that motivated it.

(More details can be found in the individual commit messages.)