### PR TITLE
Have Object.setOwnerOf return the object

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2403,6 +2403,7 @@ Interpreter.prototype.initPerms_ = function() {
       // TODO(cpcallen:perms): throw if current perms does not
       // control obj and (new) owner.
       obj.owner = /** @type {?Interpreter.Owner} */(owner);
+      return obj;
     }
   });
 };

--- a/server/tests/db/test_02_perms.js
+++ b/server/tests/db/test_02_perms.js
@@ -49,6 +49,6 @@ tests.getOwnerOf = function() {
 tests.setOwnerOf = function() {
   var bob = {};
   var obj = {};
-  Object.setOwnerOf(obj, bob);
-  console.assert(Object.getOwnerOf(obj) === bob, 'setOwenerOf');
+  console.assert(Object.setOwnerOf(obj, bob) === obj, 'setOwneerOf return');
+  console.assert(Object.getOwnerOf(obj) === bob, 'setOwenerOf effect');
 };

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -2897,8 +2897,7 @@ module.exports = [
   { name: 'setOwnerOf', src: `
     var bob = {};
     var obj = {};
-    Object.setOwnerOf(obj, bob);
-    Object.getOwnerOf(obj) === bob;
+    Object.setOwnerOf(obj, bob) === obj && Object.getOwnerOf(obj) === bob;
     `,
     expected: true
   },


### PR DESCRIPTION
This is to make it conform to the custom established by `Object.setPrototypeOf` and `Object.defineProperties`, and allows code like:

```JS
obj = Object.setOwnerOf(
          Object.setPrototypeOf(
              Object.defineProperties({
                key: 'value',
              }, {
                key: {enumerable: false},
              ),
              myProto),
          myOwner);
```

Not pretty - but pretty useful in some cases, such as in the editor.