### PR TITLE
Update dependencies, including to Node.js v14

### DIFF
--- a/server/codecity
+++ b/server/codecity
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --harmony-weak-refs
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2017 Google LLC

--- a/server/dump
+++ b/server/dump
@@ -256,6 +256,7 @@ var configFromSpec = function(spec) {
  * A synchronous writable stream, with an API that is a simplified
  * subset of stream.Writable.
  * @constructor
+ * @struct
  * @implements Writable
  * @param {string} filename The file to write to.
  */

--- a/server/dump
+++ b/server/dump
@@ -177,7 +177,7 @@ var configFromSpec = function(spec) {
           var value = item.headerSubs[key];
           if (value instanceof Array) {
             headerSubs[key] = value.join('\n');
-          } else if (typeof value === 'string' || value === undefined) {
+          } else if (typeof value === 'string') {
             headerSubs[key] = value;
           } else {
             reject('.headerSubs.' + key + ' is not a string');

--- a/server/dump
+++ b/server/dump
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --harmony-weak-refs
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2018 Google LLC

--- a/server/externs/WeakRef.js
+++ b/server/externs/WeakRef.js
@@ -24,20 +24,6 @@
 
 /**
  * @constructor
- * @param {T} target
- * @template T
- */
-// TODO(cpcallen): Make T bounded to {!Object} once closure-compiler
-// supports bounded generic types.
-var WeakRef = function(target) {};
-
-/**
- * @return {T}
- */
-WeakRef.prototype.deref = function() {};
-
-/**
- * @constructor
  * @param {function(!Iterator<HOLDINGS>)} cleanupCallback
  * @template TARGET, HOLDINGS, TOKEN
  */

--- a/server/externs/WeakRef.js
+++ b/server/externs/WeakRef.js
@@ -16,38 +16,35 @@
  */
 
 /**
- * @fileoverview Closure Compiler externs for the new tc39 WeakRef and
- *     FinalizationGroup API https://github.com/tc39/proposal-weakrefs
+ * @fileoverview Closure Compiler externs for the new ES2020  WeakRef and
+ *     FinalizationRegistry API https://tc39.es/ecma262/#sec-managing-memory
  * @author cpcallen@google.com (Christopher Allen)
  * @externs
  */
 
+// Closure Compiler (as of google-closue-compiler@20210406.0.0) now
+// knows about WeakRef, but it doesn't yet know about FinalizationRegistry.
+
 /**
  * @constructor
- * @param {function(!Iterator<HOLDINGS>)} cleanupCallback
+ * @param {function(HOLDINGS)} cleanupCallback
  * @template TARGET, HOLDINGS, TOKEN
  */
 // TODO(cpcallen): Make TARGET and TOKEN bounded to {!Object} once
 // closure-compiler supports bounded generic types.
-var FinalizationGroup = function(cleanupCallback) {};
+var FinalizationRegistry = function(cleanupCallback) {};
 
 /**
  * @param {TARGET} target
  * @param {HOLDINGS} holdings
- * @param {?TOKEN} unregisterToken
+ * @param {TOKEN=} unregisterToken
  * @return {void}
  */
-FinalizationGroup.prototype.register =
+FinalizationRegistry.prototype.register =
     function(target, holdings, unregisterToken) {};
 
 /**
- * @param {?TOKEN} unregisterToken
+ * @param {TOKEN} unregisterToken
  * @return {void}
  */
-FinalizationGroup.prototype.unregister = function(unregisterToken) {};
-
-/**
- * @param {function(!Iterator<HOLDINGS>)} cleanupCallback
- * @return {void}
- */
-FinalizationGroup.prototype.cleanupSome = function(cleanupCallback) {};
+FinalizationRegistry.prototype.unregister = function(unregisterToken) {};

--- a/server/externs/WeakRef.js
+++ b/server/externs/WeakRef.js
@@ -27,8 +27,10 @@
 
 /**
  * @constructor
+ * @struct
  * @param {function(HOLDINGS)} cleanupCallback
  * @template TARGET, HOLDINGS, TOKEN
+ * @nosideeffects
  */
 // TODO(cpcallen): Make TARGET and TOKEN bounded to {!Object} once
 // closure-compiler supports bounded generic types.

--- a/server/externs/WeakRef.js
+++ b/server/externs/WeakRef.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview Closure Compiler externs for the new ES2020  WeakRef and
+ * @fileoverview Closure Compiler externs for the new ES2020 WeakRef and
  *     FinalizationRegistry API https://tc39.es/ecma262/#sec-managing-memory
  * @author cpcallen@google.com (Christopher Allen)
  * @externs

--- a/server/externs/buffer/buffer.js
+++ b/server/externs/buffer/buffer.js
@@ -25,7 +25,7 @@
 
 // TODO(cpcallen): Use official externs directly.
 
-/** @constructor */
+/** @constructor @struct */
 var Buffer = function() {};
 
 exports.Buffer = Buffer;

--- a/server/externs/crypto/crypto.js
+++ b/server/externs/crypto/crypto.js
@@ -38,10 +38,11 @@ var crypto = {};
 crypto.createHash = function(algorithm) {};
 
 /**
+ * @constructor
+ * @struct
+ * @extends stream.Transform
  * @param {string} algorithm
  * @param {Object=} options
- * @constructor
- * @extends stream.Transform
  */
 crypto.Hash = function(algorithm, options) {};
 

--- a/server/externs/events/events.js
+++ b/server/externs/events/events.js
@@ -27,7 +27,7 @@ var events = {};
 /** @type {symbol} */
 events.errorMonitor;
 
-/** @constructor */
+/** @constructor @struct */
 events.EventEmitter = function() {};
 
 /**
@@ -42,13 +42,13 @@ events.EventEmitter.prototype.on = function(event, listener) {};
  * @param {function(...)} listener
  * @return {events.EventEmitter}
  */
-events.EventEmitter.prototype.removeListener = function(event, listener) {};
+events.EventEmitter.prototype.once = function(event, listener) {};
 
 /**
- * @param {string} event
+ * @param {string|symbol} event
  * @param {function(...)} listener
  * @return {events.EventEmitter}
  */
-events.EventEmitter.prototype.once = function(event, listener) {};
+events.EventEmitter.prototype.removeListener = function(event, listener) {};
 
 module.exports = events;

--- a/server/externs/fs/fs.js
+++ b/server/externs/fs/fs.js
@@ -56,6 +56,7 @@ fs.createReadStream = function(path, options) {};
 
 /**
  * @constructor
+ * @struct
  * @extends stream.ReadableStream
  */
 fs.ReadStream = function () {};
@@ -71,6 +72,7 @@ fs.createWriteStream = function(path, options) {};
 
 /**
  * @constructor
+ * @struct
  * @extends stream.WritableStream
  */
 fs.WriteStream = function () {};
@@ -138,7 +140,7 @@ fs.writeFileSync = function(filename, data, encoding) {};
  */
 fs.writeSync = function(fd, string, position, encoding) {};
                         
-/** @constructor */
+/** @constructor @struct */
 fs.Stats = function () {};
 
 /** @return {boolean} */

--- a/server/externs/http/http.js
+++ b/server/externs/http/http.js
@@ -45,9 +45,10 @@ http.requestListener;
 http.createServer;
 
 /**
- * @param {http.requestListener=} listener
  * @constructor
+ * @struct
  * @extends events.EventEmitter
+ * @param {http.requestListener=} listener
  */
 http.Server = function(listener) {};
 
@@ -65,6 +66,7 @@ http.Server.prototype.close;
 
 /**
  * @constructor
+ * @struct
  * @extends stream.Readable
  */
 http.IncomingMessage = function() {};
@@ -128,6 +130,7 @@ http.IncomingMessage.prototype.setTimeout;
 
 /**
  * @constructor
+ * @struct
  * @extends events.EventEmitter
  * @private
  */
@@ -191,6 +194,7 @@ http.ServerResponse.prototype.end;
 
 /**
  * @constructor
+ * @struct
  * @extends events.EventEmitter
  * @private
  */
@@ -233,6 +237,7 @@ http.get = function(urlOrOptions, optionsOrCallback, callback) {};
 
 /**
  * @constructor
+ * @struct
  * @extends events.EventEmitter
  */
 http.Agent = function() {};

--- a/server/externs/https/https.js
+++ b/server/externs/https/https.js
@@ -34,6 +34,7 @@ var https = {};
 
 /**
  * @constructor
+ * @struct
  * @extends tls.Server
  */
 https.Server = function() {};
@@ -80,6 +81,7 @@ https.get = function(urlOrOptions, optionsOrCallback, callback) {};
 
 /**
  * @constructor
+ * @struct
  * @extends http.Agent
  */
 https.Agent = function() {};

--- a/server/externs/net/net.js
+++ b/server/externs/net/net.js
@@ -60,6 +60,7 @@ net.createConnection = function(arg1, arg2, arg3) {};
 
 /**
  * @constructor
+ * @struct
  * @param {createOptions=} options
  * @extends {events.EventEmitter}
  */
@@ -91,6 +92,7 @@ net.Server.prototype.listen = function(port, host, backlog, callback) {};
 
 /**
  * @constructor
+ * @struct
  * @param {{fd: ?*, type: ?string, allowHalfOpen: ?boolean}=} options
  * @extends events.EventEmitter
  */
@@ -103,5 +105,13 @@ net.Socket = function(options) {};
  * @return {void}
  */
 net.Socket.prototype.write = function(data, encoding, callback) {};
+
+/**
+ * @param {(string|Buffer)=} data
+ * @param {(string|function(...))=} encoding
+ * @param {function(...)=} callback
+ * @return {void}
+ */
+net.Socket.prototype.end = function(data, encoding, callback) {};
 
 module.exports = net;

--- a/server/externs/node.js
+++ b/server/externs/node.js
@@ -94,14 +94,14 @@ process.kill = function (pid, signal) {};
  *     (===require('events')), but redefined here since
  *     closure-compiler won't let us require() that definition in an
  *     externs file.
- * @param {string} event
+ * @param {string|symbol} event
  * @param {function(...)} listener
  */
 process.on = function(event, listener) {};
 
 /**
  * Also inherited from EventEmitter.
- * @param {string} event
+ * @param {string|symbol} event
  * @param {function(...)} listener
  */
 process.once = function(event, listener) {};

--- a/server/externs/stream/stream.js
+++ b/server/externs/stream/stream.js
@@ -33,8 +33,9 @@ var stream = {};
 
 /**
  * @constructor
- * @param {Object=} options
+ * @struct
  * @extends events.EventEmitter
+ * @param {Object=} options
  */
 stream.Stream = function(options) {};
 
@@ -47,8 +48,9 @@ stream.Stream.prototype.pipe;
 
 /**
  * @constructor
- * @param {Object=} options
+ * @struct
  * @extends stream.Stream
+ * @param {Object=} options
  */
 stream.Readable = function(options) {};
 
@@ -114,6 +116,7 @@ stream.Readable.prototype.wrap;
 
 /**
  * @constructor
+ * @struct
  * @extends stream.Readable
  */
 stream.ReadableStream = function() {};
@@ -136,8 +139,9 @@ stream.ReadableStream.prototype.destroy;
 
 /**
  * @constructor
- * @param {Object=} options
+ * @struct
  * @extends stream.Stream
+ * @param {Object=} options
  */
 stream.Writable = function(options) {};
 
@@ -174,6 +178,7 @@ stream.Writable.prototype.end;
 
 /**
  * @constructor
+ * @struct
  * @extends stream.Writable
  */
 stream.WritableStream = function() {};
@@ -215,9 +220,8 @@ stream.WritableStream.prototype.destroySoon;
 
 /**
  * @constructor
- * @param {Object=} options
+ * @struct
  * @extends stream.Readable
- * Xextends stream.Writable
  */
 stream.Duplex = function(options) {};
 
@@ -228,9 +232,10 @@ stream.Duplex.prototype.allowHalfOpen;
 
 
 /**
- * @param {Object=} options
  * @constructor
+ * @struct
  * @extends stream.Duplex
+ * @param {Object=} options
  */
 stream.Transform = function(options) {};
 
@@ -251,9 +256,10 @@ stream.Transform._transform;
 stream.Transform._flush;
 
 /**
- * @param {Object=} options
  * @constructor
+ * @struct
  * @extends stream.Transform
+ * @param {Object=} options
  */
 stream.PassThrough = function(options) {};
 

--- a/server/externs/tls/tls.js
+++ b/server/externs/tls/tls.js
@@ -37,6 +37,8 @@ var tls = {};
 
 /**
  * @constructor
+ * @struct
+ * @extends stream.Stream
  */
 tls.CreateOptions = function () {};
 
@@ -93,12 +95,14 @@ tls.connect = function(port, host, options, callback) {};
 
 /**
  * @constructor
+ * @struct
  * @extends events.EventEmitter
  */
 tls.SecurePair = function() {};
 
 /**
  * @constructor
+ * @struct
  * @extends net.Server
  */
 tls.Server = function() {};
@@ -112,6 +116,7 @@ tls.Server.prototype.addContext = function(hostname, credentials) {};
 
 /**
  * @constructor
+ * @struct
  * @extends stream.Duplex
  */
 tls.CleartextStream = function() {};

--- a/server/iterable_weakmap.js
+++ b/server/iterable_weakmap.js
@@ -22,7 +22,7 @@
 'use strict';
 
 /**
- * A WeakRef<KEY>, value tuple in an IterableWeakMap.
+ * A (WeakRef<KEY>, value) tuple in an IterableWeakMap.
  * @template KEY, VALUE
  */
 class Cell {
@@ -54,8 +54,8 @@ class IterableWeakMap extends WeakMap {
     super();
     /** @private @const @type {!Set<!WeakRef<KEY>>} */
     this.refs_ = new Set();
-    /** @private @const @type {!FinalizationGroup} */
-    this.finalisers_ = new FinalizationGroup(IterableWeakMap.cleanup_);
+    /** @private @const @type {!FinalizationRegistry} */
+    this.finalisers_ = new FinalizationRegistry(IterableWeakMap.cleanup_);
 
     if (iterable === null || iterable === undefined) {
       return;
@@ -77,13 +77,13 @@ class IterableWeakMap extends WeakMap {
 
   /**
    * Remove dead cells from .refs_.  Called automatically by the
-   * .finalisers_ FinalizationGroup.
+   * .finalisers_ FinalizationRegistry.
+   * @template KEY
+   * @param {{set: !Set<!WeakRef<KEY>>, ref: !WeakRef<KEY>}} holding
    * @return {void}
    */
-  static cleanup_(iterator) {
-    for (const {set, ref} of iterator) {
-      set.delete(ref);
-    }
+  static cleanup_(holding) {
+    holding.set.delete(holding.ref);
   }
 
   /**

--- a/server/iterable_weakset.js
+++ b/server/iterable_weakset.js
@@ -38,8 +38,8 @@ class IterableWeakSet {
     this.refs_ = new Set();
     /** @private @const @type {!WeakMap<VALUE, !WeakRef<VALUE>>}} */
     this.map_ = new WeakMap();
-    /** @private @const @type {!FinalizationGroup} */
-    this.finalisers_ = new FinalizationGroup(IterableWeakSet.cleanup_);
+    /** @private @const @type {!FinalizationRegistry} */
+    this.finalisers_ = new FinalizationRegistry(IterableWeakSet.cleanup_);
 
     if (iterable === null || iterable === undefined) {
       return;
@@ -78,13 +78,13 @@ class IterableWeakSet {
 
   /**
    * Remove dead cells from .refs_.  Called automatically by the
-   * .finalisers_ FinalizationGroup.
+   * .finalisers_ FinalizationRegistry.
+   * @template KEY
+   * @param {{set: !Set<!WeakRef<KEY>>, ref: !WeakRef<KEY>}} holding
    * @return {void}
    */
-  static cleanup_(iterator) {
-    for (const {set, ref} of iterator) {
-      set.delete(ref);
-    }
+  static cleanup_(holding) {
+    holding.set.delete(holding.ref);
   }
 
   /**

--- a/server/iterable_weakset.js
+++ b/server/iterable_weakset.js
@@ -23,6 +23,7 @@
 
 /**
  * A WeakSet implementing the full Set interface, including iterability.
+ * @struct
  * @extends {WeakSet}
  * @implements {Iterable<!Array<VALUE>>}
  * @template VALUE

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,13 +1,330 @@
 {
   "name": "codecity-server",
   "version": "0.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "codecity-server",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.1.1"
+      },
+      "devDependencies": {
+        "google-closure-compiler": "^20210406.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
+      "integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/clone-stats": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "dev": true
+    },
+    "node_modules/cloneable-readable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/google-closure-compiler": {
+      "version": "20210406.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20210406.0.0.tgz",
+      "integrity": "sha512-qaQqEjIneTK5OXYfZmGnWwy5S1nYLeTTphpbc7LzhsvEq4s2xapKCi6fC8VsbCHZvgq8z5VNomMJU97ErRCyGQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "2.x",
+        "google-closure-compiler-java": "^20210406.0.0",
+        "minimist": "1.x",
+        "vinyl": "2.x",
+        "vinyl-sourcemaps-apply": "^0.2.0"
+      },
+      "bin": {
+        "google-closure-compiler": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "optionalDependencies": {
+        "google-closure-compiler-linux": "^20210406.0.0",
+        "google-closure-compiler-osx": "^20210406.0.0",
+        "google-closure-compiler-windows": "^20210406.0.0"
+      }
+    },
+    "node_modules/google-closure-compiler-java": {
+      "version": "20210406.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20210406.0.0.tgz",
+      "integrity": "sha512-hVOoFiIenZuicZSLqi4sNdwzWeg9hRi3acpvOy6WPwKQUuUNkSXNtUiiXpKgCY5puDs49onhV7FzAHoQ/908lg==",
+      "dev": true
+    },
+    "node_modules/google-closure-compiler-linux": {
+      "version": "20210406.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20210406.0.0.tgz",
+      "integrity": "sha512-KzE39AD3OOZMkR1TtE3nwPBhB3eEJwH8w4Jm3vx2k4veFhryWASFAnDMfHcASzlzjk05tPjecuFtGrHhVafL+w==",
+      "cpu": [
+        "x64",
+        "x86"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/google-closure-compiler-osx": {
+      "version": "20210406.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20210406.0.0.tgz",
+      "integrity": "sha512-Kph0hewevDC2T3uEQSRFoZAI5oE18ceyx5gUy93B0fd8cbL7vUCVjazBcHKOUiQ/Opq2CT96V0moCSFEhq8d1w==",
+      "cpu": [
+        "x64",
+        "x86"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/google-closure-compiler-windows": {
+      "version": "20210406.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20210406.0.0.tgz",
+      "integrity": "sha512-IlFWn3vv8SLCRcxK6MSfRgnU4we7zy+s6OczmEmH4wymkpRM6aydAaD4Vxz68i00Om0hkT5l2oO3cFq5FiQBLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "node_modules/replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/vinyl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+      "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+      "dev": true,
+      "dependencies": {
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/vinyl-sourcemaps-apply": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "dev": true,
+      "dependencies": {
+        "source-map": "^0.5.1"
+      }
+    }
+  },
   "dependencies": {
     "acorn": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
+      "integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -86,52 +403,45 @@
       "dev": true
     },
     "google-closure-compiler": {
-      "version": "20191111.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20191111.0.0.tgz",
-      "integrity": "sha512-Ji+FaqYKXNbJ78N5Do6hu61mPrB9D+8xSnmRO59u2CrIbmNCtoFnqkCAAL4Ye8LR8foRqtkDdiKJSblpe+5ttg==",
+      "version": "20210406.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20210406.0.0.tgz",
+      "integrity": "sha512-qaQqEjIneTK5OXYfZmGnWwy5S1nYLeTTphpbc7LzhsvEq4s2xapKCi6fC8VsbCHZvgq8z5VNomMJU97ErRCyGQ==",
       "dev": true,
       "requires": {
         "chalk": "2.x",
-        "google-closure-compiler-java": "^20191111.0.0",
-        "google-closure-compiler-js": "^20191111.0.0",
-        "google-closure-compiler-linux": "^20191111.0.0",
-        "google-closure-compiler-osx": "^20191111.0.0",
-        "google-closure-compiler-windows": "^20191111.0.0",
+        "google-closure-compiler-java": "^20210406.0.0",
+        "google-closure-compiler-linux": "^20210406.0.0",
+        "google-closure-compiler-osx": "^20210406.0.0",
+        "google-closure-compiler-windows": "^20210406.0.0",
         "minimist": "1.x",
         "vinyl": "2.x",
         "vinyl-sourcemaps-apply": "^0.2.0"
       }
     },
     "google-closure-compiler-java": {
-      "version": "20191111.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20191111.0.0.tgz",
-      "integrity": "sha512-JgsQtJVVgDuj50VPQV1OgHxMy78daTL3d607V6zF/qETl3rEEiazEGfXDGUX/1V1SUOW+Y03Ct9bcO3LMxNlxg==",
-      "dev": true
-    },
-    "google-closure-compiler-js": {
-      "version": "20191111.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-js/-/google-closure-compiler-js-20191111.0.0.tgz",
-      "integrity": "sha512-W3Oy5NF5CMgUv31CMbgLN7zhdCTVMTnNI//iEPYMotzXfX8viyOnTMipDDwJNeMnY7lfXbQrYOo+QkWP6WzZtg==",
+      "version": "20210406.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20210406.0.0.tgz",
+      "integrity": "sha512-hVOoFiIenZuicZSLqi4sNdwzWeg9hRi3acpvOy6WPwKQUuUNkSXNtUiiXpKgCY5puDs49onhV7FzAHoQ/908lg==",
       "dev": true
     },
     "google-closure-compiler-linux": {
-      "version": "20191111.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20191111.0.0.tgz",
-      "integrity": "sha512-pxxB83Ae7G9OHFSOEzOYlp844YyqQgU1RXBpCGBKeDAQrs3dykHqRhNGZdI7N1tsby/pT+hKL1US2l/CslPqag==",
+      "version": "20210406.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20210406.0.0.tgz",
+      "integrity": "sha512-KzE39AD3OOZMkR1TtE3nwPBhB3eEJwH8w4Jm3vx2k4veFhryWASFAnDMfHcASzlzjk05tPjecuFtGrHhVafL+w==",
       "dev": true,
       "optional": true
     },
     "google-closure-compiler-osx": {
-      "version": "20191111.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20191111.0.0.tgz",
-      "integrity": "sha512-sviL1DLN+dDfYBLzmU6+2Yk19P1uzUHQuKaXrHxEYZkU4jTJNq/TC4xi6t0ZgvLQEm2Vf7xhOrt80TYKnoQaVg==",
+      "version": "20210406.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20210406.0.0.tgz",
+      "integrity": "sha512-Kph0hewevDC2T3uEQSRFoZAI5oE18ceyx5gUy93B0fd8cbL7vUCVjazBcHKOUiQ/Opq2CT96V0moCSFEhq8d1w==",
       "dev": true,
       "optional": true
     },
     "google-closure-compiler-windows": {
-      "version": "20191111.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20191111.0.0.tgz",
-      "integrity": "sha512-iKdz2bWrrM4zLv3USCRtWX4kLWzZhbj/afh/W6giLxg5XQzbNg+UpVF+2G6f/LEYK9UNBgS2TdyNTuw8mod+Mg==",
+      "version": "20210406.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20210406.0.0.tgz",
+      "integrity": "sha512-IlFWn3vv8SLCRcxK6MSfRgnU4we7zy+s6OczmEmH4wymkpRM6aydAaD4Vxz68i00Om0hkT5l2oO3cFq5FiQBLg==",
       "dev": true,
       "optional": true
     },

--- a/server/package.json
+++ b/server/package.json
@@ -4,10 +4,10 @@
   "description": "Server for the Code City project",
   "main": "codecity.js",
   "dependencies": {
-    "acorn": "^7.1.1"
+    "acorn": "^8.1.1"
   },
   "devDependencies": {
-    "google-closure-compiler": "^20191111.0.0"
+    "google-closure-compiler": "^20210406.0.0"
   },
   "scripts": {
     "compile": "./compile",

--- a/server/priorityqueue.js
+++ b/server/priorityqueue.js
@@ -53,6 +53,7 @@ function children(i) {
 
 /**
  * A priority queue.
+ * @stuct
  * @template T
  */
 class PriorityQueue {

--- a/server/repl
+++ b/server/repl
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --harmony-weak-refs
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2018 Google LLC

--- a/server/selector.js
+++ b/server/selector.js
@@ -27,6 +27,7 @@ var code = require('./code');
  * Type for all "special" selector parts (ones which do not represent
  * named variables / properties).
  * @constructor
+ * @struct
  */
 var SpecialPart = function(type) {
   this.type = type;

--- a/server/tests/iterable_weakmap_test.js
+++ b/server/tests/iterable_weakmap_test.js
@@ -36,11 +36,10 @@ async function gcAndFinalise() {
   // Cycle event loop to allow finalisers to run.  Need to cycle it
   // once before GC to ensure that WeakRefs can be cleared (their
   // targets can never be cleared in the same turn as the WeakRef was
-  // created), then again after to allow finalisers to run (though,
-  // as of node v12.12.0, the await with which this function is called
-  // is sufficient to achieve the second cycle).
+  // created), then again after to allow finalisers to run.
   await new Promise((res, rej) => setImmediate(res));
   gc();
+  await new Promise((res, rej) => setImmediate(res));
 }
   
 /**

--- a/server/tests/iterable_weakset_test.js
+++ b/server/tests/iterable_weakset_test.js
@@ -36,11 +36,10 @@ async function gcAndFinalise() {
   // Cycle event loop to allow finalisers to run.  Need to cycle it
   // once before GC to ensure that WeakRefs can be cleared (their
   // targets can never be cleared in the same turn as the WeakRef was
-  // created), then again after to allow finalisers to run (though,
-  // as of node v12.12.0, the await with which this function is called
-  // is sufficient to achieve the second cycle).
+  // created), then again after to allow finalisers to run.
   await new Promise((res, rej) => setImmediate(res));
   gc();
+  await new Promise((res, rej) => setImmediate(res));
 }
 
 /**

--- a/server/tests/run
+++ b/server/tests/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Run unit tests in Node.
-node --harmony-weak-refs --expose-gc tests/run.js
+node --expose-gc tests/run.js
 
 # Delete any existing checkpoint files.
 rm tests/db/*.city


### PR DESCRIPTION
Update Acorn, Closure Compiler to the latest available npm version, and update our code to run on Node.js v14, which finally includes `WeakRef` as standard.

Also fix some compile warnings, create some more and fix most of them, and fix some tests.

Left for a future PR are one compile warning and one test failure, both of which concern buggy code in `Dumper`.