### PR TITLE
Dumper code-generation improvements: use .write's var_args and .exprForCall_

### DIFF
--- a/server/dumper.js
+++ b/server/dumper.js
@@ -198,14 +198,14 @@ Dumper.prototype.dump = function() {
   // Dump all remaining bindings.
   this.global.dump(this);
 
-  // Dump listening sockets.
+  // Dump listening Servers.
   for (var key in this.intrp2.listeners_) {
     var port = Number(key);
-    var listener = this.intrp2.listeners_[port];
+    var server = this.intrp2.listeners_[port];
     this.write(this.exprForBuiltin_('CC.connectionListen'), '(',
-               String(port), ',',
-               this.exprFor_(listener.proto), ', ',
-               this.exprFor_(listener.timeLimit), ');');
+               this.exprFor_(port), ', ', this.exprFor_(server.proto),
+               (server.timeLimit ? ', ' + this.exprFor_(server.timeLimit) : ''),
+               ');');
   }
 };
 

--- a/server/dumper.js
+++ b/server/dumper.js
@@ -287,7 +287,7 @@ Dumper.prototype.exprFor_ = function(value, ref, callable, funcName) {
   if (ref) objDumper.updateRef(ref);  // Safe new ref if specified.
   if (selector) return this.exprForSelector_(selector);
 
- // Object not yet referenced.  Is it a builtin?
+  // Object not yet referenced.  Is it a builtin?
   var key = intrp2.builtins.getKey(value);
   if (key) {
     var quoted = code.quote(key);
@@ -296,8 +296,11 @@ Dumper.prototype.exprFor_ = function(value, ref, callable, funcName) {
 
   // Seems to be a new object.  Check it really doesn't exist already
   // and that it will be referenceable.
-  if (objDumper.proto !== undefined) throw new Error('object already exists');
-  if (!objDumper.ref) throw Error('refusing to create non-referable object');
+  if (objDumper.proto !== undefined) {
+    throw new Error('object already exists but is not referenced');
+  } else if (!objDumper.ref) {
+    throw new Error('refusing to create non-referable object');
+  }
 
   var expr;
   if (value instanceof intrp2.Function) {

--- a/server/dumper.js
+++ b/server/dumper.js
@@ -257,8 +257,9 @@ Dumper.prototype.dumpBinding = function(selector, todo) {
  * expression referenceing the previously-constructed object.
  *
  * This method is mostly a wrapper around the other .exprFor<Foo>_
- * methods (but notably not .exprForBuiltin_, which is a wrapper
- * around this method); see them for examples of expected output.
+ * methods (but notably not .exprForBuiltin_ and .exprForCall_, which
+ * are wrappers around this method); see them for examples of expected
+ * output.
  *
  * @private
  * @param {Interpreter.Value} value Arbitrary JS value from this.intrp2.
@@ -363,6 +364,28 @@ Dumper.prototype.exprForArray_ = function(arr, arrDumper) {
  */
 Dumper.prototype.exprForBuiltin_ = function(builtin) {
   return this.exprFor_(this.intrp2.builtins.get(builtin), undefined, true);
+};
+
+/**
+ * Get a source text representation of a call to a given builtin
+ * function.  The array of arguments can contain either
+ * Interpreter.Values or Selectors, which will be passed to .exprFor_
+ * and .exprForSelector_, respectively.
+ * @private
+ * @param {string} builtin The name of the builtin function to call.
+ * @param {!Array<!Selector|Interpreter.Value>=} args Arguments to the  call.
+ * @return {string} An eval-able representation of a builtin function call.
+ */
+Dumper.prototype.exprForCall_ = function(builtin, args) {
+  var dumper = this;
+  return this.exprForBuiltin_(builtin) + '(' +
+      Array.from(args || []).map(function (argument) {
+        if (argument instanceof Selector) {
+          return dumper.exprForSelector_(argument);
+        } else {
+          return dumper.exprFor_(argument);
+        }
+      }).join(', ') + ')';
 };
 
 /**

--- a/server/dumper.js
+++ b/server/dumper.js
@@ -202,9 +202,10 @@ Dumper.prototype.dump = function() {
   for (var key in this.intrp2.listeners_) {
     var port = Number(key);
     var listener = this.intrp2.listeners_[port];
-    this.write(this.exprForBuiltin_('CC.connectionListen') + '(' +
-        port + ', ' + this.exprFor_(listener.proto) + ', ' +
-        this.exprFor_(listener.timeLimit) + ');');
+    this.write(this.exprForBuiltin_('CC.connectionListen'), '(',
+               String(port), ',',
+               this.exprFor_(listener.proto), ', ',
+               this.exprFor_(listener.timeLimit), ');');
   }
 };
 

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -370,8 +370,9 @@ Interpreter.prototype.step_ = function(thread, stack) {
 };
 
 /**
- * If interpreter status is RUNNING, use setTimeout to repeatedly call
- * .run() until there are no more sleeping threads.
+ * If interpreter status is RUNNING, use setTimeout to arrange for
+ * .run() to be called repeatedly until there are no more sleeping
+ * threads.
  * @private
  */
 Interpreter.prototype.go_ = function() {

--- a/server/tests/dumper_test.js
+++ b/server/tests/dumper_test.js
@@ -211,7 +211,13 @@ exports.testDumperPrototypeExprForPrimitive_ = function(t) {
  * @suppress {accessControls}
  */
 exports.testDumperPrototypeExprFor_ = function(t) {
+  // Create an Interperter with a UserFunction to dump.
   const intrp = new Interpreter();
+  intrp.createThreadForSrc('function foo(bar) {}');
+  intrp.run();
+  const func = /** @type {!Interpreter.prototype.UserFunction} */ (
+      intrp.global.get('foo'));
+
   const pristine = new Interpreter();
   const dumper = new Dumper(pristine, intrp);
 
@@ -223,11 +229,8 @@ exports.testDumperPrototypeExprFor_ = function(t) {
     dumper.getObjectDumper_(/** @type {!Interpreter.prototype.Object} */
         (intrp.builtins.get(b))).ref = new Components(dumper.global, b);
   }
-
-  // Create UserFunction to dump.
-  intrp.createThreadForSrc('function foo(bar) {}');
-  intrp.run();
-  const func = intrp.global.get('foo');
+  // Give foo a reference too, even though it has not been created yet.
+  dumper.getObjectDumper_(func).ref = new Components(dumper.global, 'foo');
 
   const cases = [
     [intrp.OBJECT, "new 'Object.prototype'"],

--- a/server/tests/dumper_test.js
+++ b/server/tests/dumper_test.js
@@ -447,6 +447,47 @@ exports.testDumperPrototypeExprForSelector_ = function(t) {
 };
 
 /**
+ * Unit tests for the Dumper.prototype.exprForCall_ method.
+ * @param {!T} t The test runner object.
+ * @suppress {accessControls}
+ */
+exports.testDumperPrototypeExprForCall_ = function(t) {
+  const intrp = new Interpreter();
+  const pristine = new Interpreter();
+  const dumper = new Dumper(pristine, intrp);
+
+  // Test dumping builtin calls with no arguments.  Note that eval is
+  // inserted in the global Scope at Interpreter construction time,
+  // while escape is not.
+  t.expect("Dumper.p.exprForCall_('eval')",
+           dumper.exprForCall_('eval'),
+           'eval()');  // eval is inserted in global scope at creation.
+
+  t.expect("Dumper.p.exprForCall_('escape')",
+           dumper.exprForCall_('escape'),
+           "(new 'escape')()");
+
+  // Test dumping builtin calls with primitive arguments.
+  t.expect("Dumper.p.exprForCall_('eval', [true])",
+           dumper.exprForCall_('eval', [true]),
+           "eval(true)");
+
+  t.expect("Dumper.p.exprForCall_('eval', ['foo', 42])",
+           dumper.exprForCall_('eval', ['foo', 42]),
+           "eval('foo', 42)");
+
+  // Test dumping builtin calls with object arguments.
+  t.expect("Dumper.p.exprForCall_('eval', [eval])",
+           dumper.exprForCall_('eval', [intrp.builtins.get('eval')]),
+           "eval(eval)");
+
+  // Test dumping builtin calls with Selector arguments.
+  t.expect("Dumper.p.exprForCall_('eval', [new Selector('foo.bar.baz')])",
+           dumper.exprForCall_('eval', [new Selector('foo.bar.baz')]),
+           "eval(foo.bar.baz)");
+};
+
+/**
  * Tests for the Dumper.prototype.dumpBinding method, and by
  * implication most of ScopeDumper and ObjectDumper.
  * @param {!T} t The test runner object.


### PR DESCRIPTION
* Use `Dumper.prototype.write`'s ability to accept variable numbers of arguments to avoid sting concatenation where possible.
* Introduce `Dumper. prototype.exprForCall_` to simplify generation of calls to builtin functions.
* Fix test of `Dumper.prototype.dump` that was broken when code to dump `Server` `.timeLimit`s added in 91d3959  (PR #453)