### PR TITLE
Dumper misc. changes

### DIFF
--- a/server/dumper.js
+++ b/server/dumper.js
@@ -1931,11 +1931,9 @@ ObjectDumper.prototype.updateRef = function(dumper, ref) {
   if (reachable(this.ref)) {
     if (reachable(ref)) {  // Both existing and new refs reachable.
       if (this.preferredRef) {  // Prefer .preferredRef over others.
-        if (this.ref.dumper === this.preferredRef.dumper &&
-            this.ref.part === this.preferredRef.part) {
+        if (this.preferredRef.equals(this.ref)) {
           return;
-        } else if(ref.dumper === this.preferredRef.dumper &&
-            ref.part === this.preferredRef.part) {
+        } else if(this.preferredRef.equals(ref)) {
           this.ref = ref;
           return;
         }
@@ -2065,6 +2063,15 @@ ObjectDumper.Pending.prototype.toString = function() {
 var Components = function(dumper, part) {
   /** @const {!SubDumper} */ this.dumper = dumper;
   /** @const {Selector.Part} */ this.part = part;
+};
+
+/**
+ * Return true iff this and that represent the same binding.
+ * @param {!Components} that Another Components to compare this with.
+ * @return {boolean}
+ */
+Components.prototype.equals = function(that) {
+  return this.dumper === that.dumper && this.part === that.part;
 };
 
 /**

--- a/server/tests/dumper_test.js
+++ b/server/tests/dumper_test.js
@@ -152,6 +152,7 @@ exports.testObjectDumperUpdateRef = function(t) {
   // Stub Dumper.
   const /** !Dumper */ dumper = /** @type {?} */({
     intrp2: intrp,
+    scope: intrp.global,
   });
 
   // Scenario 0: Reject self references.

--- a/server/tests/dumper_test.js
+++ b/server/tests/dumper_test.js
@@ -573,13 +573,20 @@ exports.testDumperPrototypeDumpBinding = function(t) {
       title: 'recursion-simple',
       src: `
         var obj = {a: {id: 'a'}, b: {id: 'b'}, c: {id: 'c'}};
+        Object.setPrototypeOf(obj.c, {id: 'd'});
       `,
       // Mark obj.b.id to be pruned, and pruneRest of obj.c.
       prune: ['obj.b.id'],
       pruneRest: ['obj.c'],
       dump: [
-        ['obj', Do.RECURSE, "var obj = {};\nobj.a = {};\nobj.a.id = 'a';\n" +
-            'obj.b = {};\nobj.c = {};\n'],
+        ['obj', Do.RECURSE,
+         'var obj = {};\n' +
+             "obj.a = {};\n" +
+             "obj.a.id = 'a';\n" +
+             'obj.b = {};\n' +
+             'obj.c = {};\n' +
+             "(new 'Object.setPrototypeOf')(obj.c, {});\n" +
+             "(new 'Object.getPrototypeOf')(obj.c).id = 'd';\n"],
       ],
       after: [
         ['obj.a', Do.RECURSE],


### PR DESCRIPTION
* Revise, clarify and document the intended behaviour of `Dumper.prototype.pruneRest` and `ObjectDumper.prototype.updateRef` (and then add tests and revise the implementation to match).
* Fix the last remaining compiler warning.

