### PR TITLE
Tidy up testcases.js

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+Language:        JavaScript
+BasedOnStyle:    Google
+ColumnLimit:     80

--- a/server/code.js
+++ b/server/code.js
@@ -69,9 +69,10 @@ regexps.string = new RegExp('(?:' + regexps.singleQuotedString.source + '|' +
 regexps.stringExact = new RegExp('^' + regexps.string.source + '$');
 
 /**
- * RegExp matching a valid JavaScript identifier.  Note that this is
- * fairly conservative, because ANY Unicode letter can appear in an
- * identifier - but the full regexp is absurdly complicated.
+ * RegExp matching a valid JavaScript identifier (strictly an
+ * IdentifierName, which does not exclude ReservedWord).  Note that
+ * this is fairly conservative, because ANY Unicode letter can appear
+ * in an identifier - but the full regexp is absurdly complicated.
  * @const
  */
 regexps.identifier = /[A-Za-z_$][A-Za-z0-9_$]*/g;

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -266,7 +266,7 @@ exports.testHasArgumentsOrEval = function(t) {
     try {
       const ast = Parser.parse(src);
       const firstStatement = ast['body'][0];
-      t.expect(name, hasArgumentsOrEval(firstStatement),
+      t.expect(`${name} ${src}`, hasArgumentsOrEval(firstStatement),
                expected, src);
     } catch (e) {
       t.crash(name, util.format('%s\n%s', src, e.stack));
@@ -287,7 +287,7 @@ exports.testSimple = function(t) {
     if ('expected' in tc) {
       const oldOptions = interpreter.options;
       if (tc.options) interpreter.options = tc.options;
-      runSimpleTest(t, tc.name, tc.src, tc.expected);
+      runSimpleTest(t, tc.name || tc.src, tc.src, tc.expected);
       if (tc.options) interpreter.options = oldOptions;
     } else {
       t.skip(tc.name);

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -3172,23 +3172,25 @@ module.exports = [
         // Perms revert at end of scope.
       })();
       r += perms().name;
-      r;`,
-      expected: 'RootBobRoot'
+      r;
+    `,
+    expected: 'RootBobRoot'
   },
   {
-      name: 'getOwnerOf',
-      src: `
+    name: 'getOwnerOf',
+    src: `
       var bob = {};
       var roots = {};
       setPerms(bob);
       var bobs = new Object;
       Object.getOwnerOf(Object) === CC.root &&
       Object.getOwnerOf(roots) === CC.root &&
-      Object.getOwnerOf(bobs) === bob`,
-      expected: true
+      Object.getOwnerOf(bobs) === bob
+    `,
+    expected: true
   },
   {
-      name: 'setOwnerOf',
+    name: 'setOwnerOf',
       src: `
       var bob = {};
       var obj = {};

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -97,7 +97,7 @@ module.exports = [
     expected: 49,
   },
   {
-    name: 'assignmentSetsAnonFuncName',
+    name: 'variable assignment sets anonymous function name',
     src: `
       var myAssignedFunc;
       myAssignedFunc = function() {};
@@ -106,12 +106,32 @@ module.exports = [
     expected: 'myAssignedFunc',
   },
   {
-    name: 'objectExprSetsAnonFuncName',
+    name: 'property assignment does not set anonymous FunctionExpression name',
+    src: `
+      var obj = {};
+      obj.myMethod = function() {};
+      obj.myMethod.name;
+    `,
+    expected: '',
+  },
+  {
+    // This one is a CodeCity extension.
+    name: 'property assignment optionally sets anonymous function name',
+    src: `
+      var obj = {};
+      obj.myMethod = function() {};
+      obj.myMethod.name;
+    `,
+    options: {methodNames: true},
+    expected: 'myMethod',
+  },
+  {
+    name: 'object expression sets anonymous FunctionExpression name',
     src: `({myPropFunc: function() {}}).myPropFunc.name;`,
     expected: 'myPropFunc',
   },
   {
-    name: 'varDeclSetsAnonFuncName',
+    name: 'variable declaration sets anonymous FunctionExpression name',
     src: `var myVarDeclFunc = function() {}; myVarDeclFunc.name;`,
     expected: 'myVarDeclFunc',
   },

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -24,42 +24,35 @@
 module.exports = [
   // Testcases for TestInterpreterSimple (have expected value):
   {
-    name: 'onePlusOne',
     src: `1 + 1;`,
     expected: 2
   },
   {
-    name: 'twoPlusTwo',
     src: `2 + 2;`,
     expected: 4
   },
   {
-    name: 'sixTimesSeven',
     src: `6 * 7;`,
     expected: 42
   },
   {
-    name: 'simpleFourFunction',
     src: `(3 + 12 / 4) * (10 - 3);`,
     expected: 42
   },
   {
-    name: 'variableDecl',
     src: `var x = 43; x;`,
     expected: 43
   },
   {
-    name: 'condTrue',
     src: `true ? 'then' : 'else';`,
     expected: 'then'
   },
   {
-    name: 'condFalse',
     src: `false ? 'then' : 'else';`,
     expected: 'else'
   },
   {
-    name: 'ifTrue',
+    name: 'if(true)',
     src: `
     if (true) {
       'then';
@@ -70,7 +63,7 @@ module.exports = [
     expected: 'then'
   },
   {
-    name: 'ifFalse',
+    name: 'if(false)',
     src: `
     if (false) {
       'then';
@@ -107,37 +100,29 @@ module.exports = [
     expected: 'TypeError'
   },
   {
-    name: 'postincrement',
     src: `var x = 45; x++; x++;`,
     expected: 46
   },
   {
-    name: 'preincrement',
     src: `var x = 45; ++x; ++x;`,
     expected: 47
   },
   {
-    name: 'concat',
     src: `'foo' + 'bar';`,
     expected: 'foobar'
   },
   {
-    name: 'plusequalsLeft',
+    name: 'Effect of += on left argument',
     src: `var x = 40, y = 8; x += y; x;`,
     expected: 48
   },
   {
-    name: 'plusequalsRight',
+    name: 'Effect of += on right argument',
     src: `var x = 40, y = 8; x += y; y;`,
     expected: 8
   },
   {
-    name: 'simpleFunctionExpression',
-    src: `
-    var v;
-    var f = function() { v = 49; };
-    f();
-    v;
+    src: `var v, f = function() { v = 49; }; f(); v;
     `,
     expected: 49
   },
@@ -238,31 +223,27 @@ module.exports = [
     expected: undefined
   },
   {
-    name: 'throwUnhandledErrorWithFinally',
-    src: `
-    try {
-      throw new Error('not caught');
-    } finally {
-    }
-    `,
+    src: `try {throw new Error('not caught');} finally {}`,
     options: {noLog: ['unhandled']},
     expected: undefined
   },
   {
-    name: 'throwUnhandledExceptionWithFinally',
-    src: `
-    try {
-      throw 'not caught';
-    } finally {
-    }
-    `,
+    src: `try {throw 'not caught';} finally {}`,
     options: {noLog: ['unhandled']},
     expected: undefined
   },
   {
-    name: 'seqExpr',
     src: `51, 52, 53;`,
     expected: 53
+  },
+  {
+    name: 'sequenceExpression',
+    src: `
+    var x, y, z;
+    x = (y = 60, z = 5, 0.5);
+    x + y + z;
+    `,
+    expected: 65.5
   },
   {
     name: 'labeledStatement',
@@ -273,37 +254,31 @@ module.exports = [
     name: 'whileLoop',
     src: `
     var a = 0;
-    while (a < 55) {
-      a++;
-    }
+    while (a < 55) a++;
     a;
     `,
     expected: 55
   },
   {
-    name: 'whileFalse',
+    name: 'while(false)',
     src: `
     var a = 56;
-    while (false) {
-      a++;
-    }
+    while (false) a++;
     a;
     `,
     expected: 56
   },
   {
-    name: 'doWhileFalse',
+    name: 'do ... while(false)',
     src: `
     var a = 56;
-    do {
-      a++;
-    } while (false);
+    do a++; while (false);
     a;
     `,
     expected: 57
   },
   {
-    name: 'breakDoWhile',
+    name: 'do ... break ... while',
     src: `
     var a = 57;
     do {
@@ -316,12 +291,11 @@ module.exports = [
     expected: 58
   },
   {
-    name: 'selfBreak',
     src: `foo: break foo;`,
     expected: undefined /* (but legal!) */
   },
   {
-    name: 'breakWithFinally',
+    name: 'try ... break ... finally',
     src: `
     var a = 6;
     foo: {
@@ -337,7 +311,7 @@ module.exports = [
     expected: 59
   },
   {
-    name: 'continueWithFinally',
+    name: 'do ... while with try ... continue ... finally ...',
     src: `
     var a = 59;
     do {
@@ -352,7 +326,7 @@ module.exports = [
     expected: 60
   },
   {
-    name: 'breakWithFinallyContinue',
+    name: 'while with try ... break ... finally continue',
     src: `
     var a = 0;
     while (a++ < 60) {
@@ -367,7 +341,7 @@ module.exports = [
     expected: 61
   },
   {
-    name: 'returnWithFinallyContinue',
+    name: 'while with try ... return ... finally continue',
     src: `
     (function() {
       var i = 0;
@@ -384,46 +358,33 @@ module.exports = [
     expected: 62
   },
   {
-    name: 'orTrue',
     src: `63 || 'foo';`,
     expected: 63
   },
   {
-    name: 'orFalse',
     src: `false || 64;`,
     expected: 64
   },
   {
-    name: 'orShortcircuit',
+    name: '|| short-circuit',
     src: `var r = 0; true || (r++); r;`,
     expected: 0
   },
   {
-    name: 'andTrue',
     src: `({}) && 65;`,
     expected: 65
   },
   {
-    name: 'andFalse',
     src: `0 && 65;`,
     expected: 0
   },
   {
-    name: 'andShortcircuit',
+    name: '&&  sort-circuit',
     src: `var r = 0; false && (r++); r;`,
     expected: 0
   },
   {
-    name: 'sequenceExpresion',
-    src: `
-    var x, y, z;
-    x = (y = 60, z = 5, 0.5);
-    x + y + z;
-    `,
-    expected: 65.5
-  },
-  {
-    name: 'forTriangular',
+    name: 'for',
     src: `
     var t = 0;
     for (var i = 0; i < 12; i++) {
@@ -535,12 +496,10 @@ module.exports = [
     expected: undefined
   },
   {
-    name: 'emptyArrayLength',
     src: `[].length;`,
     expected: 0
   },
   {
-    name: 'arrayElidedLength',
     src: `[1,,3,,].length;`,
     expected: 4
   },
@@ -676,7 +635,6 @@ module.exports = [
     expected: undefined
   },
   {
-    name: 'undefined',
     src: `undefined;`,
     expected: undefined
   },
@@ -686,22 +644,18 @@ module.exports = [
     expected: 71
   },
   {
-    name: 'unaryPlus',
     src: `+'72';`,
     expected: 72
   },
   {
-    name: 'unaryMinus',
     src: `-73;`,
     expected: -73
   },
   {
-    name: 'unaryComplement',
     src: `~0xffffffb5;`,
     expected: 74
   },
   {
-    name: 'unaryNot',
     src: `!false && (!true === false);`,
     expected: true
   },
@@ -754,7 +708,6 @@ module.exports = [
     expected: true
   },
   {
-    name: 'binaryInArrayLength',
     src: `'length' in [];`,
     expected: true
   },
@@ -858,7 +811,7 @@ module.exports = [
     expected: 'TypeError,0'
   },
   {
-    name: 'deleteProp',
+    name: 'delete',
     src: `
     var o = {foo: 'bar'};
     (delete o.quux) + ('foo' in o) + (delete o.foo) +
@@ -1065,10 +1018,7 @@ module.exports = [
     expected: '[object Arguments]'
   },
   {
-    name: 'debugger',
-    src: `
-    debugger;
-    `,
+    src: `debugger;`,
     expected: undefined
   },
   {
@@ -1100,7 +1050,6 @@ module.exports = [
     expected: 'the prototype'
   },
   {
-    name: 'regexpSimple',
     src: `/foo/.test('foobar');`,
     expected: true
   },
@@ -1462,12 +1411,10 @@ module.exports = [
     expected: 16
   },
   {
-    name: 'Object.getOwnPropertyNames number',
     src: `Object.getOwnPropertyNames(42).length`,
     expected: 0
   },
   {
-    name: 'Object.getOwnPropertyNames boolean',
     src: `Object.getOwnPropertyNames(true).length`,
     expected: 0
   },
@@ -1651,7 +1598,6 @@ module.exports = [
     expected: false
   },
   {
-    name: 'Object.protoype.isPrototypeOf unrelated',
     src: `Object.prototype.isPrototypeOf(Object.create(null))`,
     expected: false
   },
@@ -1715,12 +1661,10 @@ module.exports = [
     expected: undefined
   },
   {
-    name: 'new Function() .length',
     src: `(new Function).length;`,
     expected: 0
   },
   {
-    name: 'new Function() .toString()',
     src: `(new Function).toString()`,
     expected: 'function() {}'
   },
@@ -1730,12 +1674,10 @@ module.exports = [
     expected: 42
   },
   {
-    name: 'new Function simple .length',
     src: `(new Function('return 42;')).length;`,
     expected: 0
   },
   {
-    name: 'new Function simple .toString()',
     src: `(new Function('return 42;')).toString()`,
     expected: 'function() {return 42;}'
   },
@@ -1971,22 +1913,19 @@ module.exports = [
   },
   // N.B.: tests of class constructor semantics unavoidably ES6.
   {
-    name: 'Function.protote.bind class constructor',
+    name: 'Function.prototype.bind class constructor',
     src: `String(new (WeakMap.bind()));`,
     expected: '[object WeakMap]'
   },
   /////////////////////////////////////////////////////////////////////////////
   // Array and Array.prototype
   {
-    name: 'new Array()NoArgs',
-    src: `
-    var a = new Array;
-    Array.isArray(a) && a.length;
-    `,
+    name: 'new Array()',
+    src: `var a = new Array(); Array.isArray(a) && a.length;`,
     expected: 0
   },
   {
-    name: 'newArray(number)',
+    name: 'newArray(/* number */)',
     src: `
     var a = new Array(42);
     Array.isArray(a) && !(0 in a) && !(41 in a) && a.length;
@@ -1994,7 +1933,7 @@ module.exports = [
     expected: 42
   },
   {
-    name: 'new Array(non-number)',
+    name: 'new Array(/* non-number */)',
     src: `
     var a = new Array('foo');
     Array.isArray(a) && a.length === 1 && a[0];
@@ -2002,7 +1941,7 @@ module.exports = [
     expected: 'foo'
   },
   {
-    name: 'new Array multiple args',
+    name: 'new Array(/* multiple args */)',
     src: `
     var a = new Array(1, 2, 3);
     Array.isArray(a) && a.length === 3 && String(a);
@@ -2010,22 +1949,18 @@ module.exports = [
     expected: '1,2,3'
   },
   {
-    name: 'Array.isArray Array.prototype',
     src: `Array.isArray(Array.prototype);`,
     expected: true
   },
   {
-    name: 'Array.isArray Array instance',
     src: `Array.isArray(new Array);`,
     expected: true
   },
   {
-    name: 'Array.isArray array literal',
     src: `Array.isArray([]);`,
     expected: true
   },
   {
-    name: 'Array.isArray(array-like)',
     src: `Array.isArray({0: 'foo', 1: 'bar', length: 2});`,
     expected: false
   },
@@ -2057,12 +1992,10 @@ module.exports = [
     expected: '[object Object],baz,,quux,quuux'
   },
   {
-    name: 'Array.prototype.includes',
     src: `[1, 2, 3, 2, 1].includes(2);`,
     expected: true
   },
   {
-    name: 'Array.prototype.includes not found',
     src: `[1, 2, 3, 2, 1].includes(4);`,
     expected: false
   },
@@ -2077,7 +2010,6 @@ module.exports = [
     expected: true
   },
   {
-    name: 'Array.prototype.includes NaN',
     src: `['x', NaN, 'y'].includes(NaN);`,
     expected: true
   },
@@ -2100,12 +2032,12 @@ module.exports = [
     expected: -1
   },
   {
-    name: 'Array.prototype.indexOf(..., +)',
+    name: 'Array.prototype.indexOf fromIndex',
     src: `[1, 2, 3, 2, 1].indexOf(2, 2);`,
     expected: 3
   },
   {
-    name: 'Array.prototype.indexOf(..., -)',
+    name: 'Array.prototype.indexOf negative fromIndex',
     src: `[1, 2, 3, 2, 1].indexOf(1, -3);`,
     expected: 4
   },
@@ -2577,17 +2509,14 @@ module.exports = [
     expected: 'pass'
   },
   {
-    name: 'Boolean.prototype.toString()',
     src: `Boolean.prototype.toString();`,
     expected: 'false'
   },
   {
-    name: 'Boolean.prototype.toString.call(true)',
     src: `Boolean.prototype.toString.call(true);`,
     expected: 'true'
   },
   {
-    name: 'Boolean.prototype.toString.call(false)',
     src: `Boolean.prototype.toString.call(false);`,
     expected: 'false'
   },
@@ -2603,17 +2532,14 @@ module.exports = [
     expected: 'TypeError'
   },
   {
-    name: 'Boolean.prototype.valueOf()',
     src: `Boolean.prototype.valueOf();`,
     expected: false
   },
   {
-    name: 'Boolean.prototype.valueOf.call primitive true',
     src: `Boolean.prototype.valueOf.call(true);`,
     expected: true
   },
   {
-    name: 'Boolean.prototype.valueOf.call primitive false',
     src: `Boolean.prototype.valueOf.call(false);`,
     expected: false
   },
@@ -2667,12 +2593,10 @@ module.exports = [
     expected: true
   },
   {
-    name: 'Number.prototype.toString()',
     src: `Number.prototype.toString();`,
     expected: '0'
   },
   {
-    name: 'Number.prototype.toString.call primitive',
     src: `Number.prototype.toString.call(84);`,
     expected: '84'
   },
@@ -2688,12 +2612,10 @@ module.exports = [
     expected: 'TypeError'
   },
   {
-    name: 'Number.prototype.valueOf()',
     src: `Number.prototype.valueOf();`,
     expected: 0
   },
   {
-    name: 'Number.prototype.valueOf.call primitive',
     src: `Number.prototype.valueOf.call(85);`,
     expected: 85
   },
@@ -2802,7 +2724,6 @@ module.exports = [
     expected: 'TypeError'
   },
   {
-    name: 'String.prototype.length',
     src: `String.prototype.length;`,
     expected: 0
   },
@@ -2855,7 +2776,6 @@ module.exports = [
     expected: 2
   },
   {
-    name: 'String.prototype.toString()',
     src: `String.prototype.toString();`,
     expected: ''
   },
@@ -2876,7 +2796,6 @@ module.exports = [
     expected: 'TypeError'
   },
   {
-    name: 'String.prototype.valueOf()',
     src: `String.prototype.valueOf();`,
     expected: ''
   },
@@ -2990,17 +2909,14 @@ module.exports = [
         '"null":null,"object":{"obj":{},"arr":[]},"array":[{},[]]}'
   },
   {
-    name: 'JSON.stringify(function(){})',
     src: `JSON.stringify(function(){});`,
     expected: undefined
   },
   {
-    name: 'JSON.stringify([function(){}])',
     src: `JSON.stringify([function(){}]);`,
     expected: '[null]'
   },
   {
-    name: 'JSON.stringify({f: function(){}})',
     src: `JSON.stringify({f: function(){}});`,
     expected: '{}'
   },
@@ -3168,7 +3084,7 @@ module.exports = [
     expected: '1,13'
   },
   {
-    name: 'Thread.callers()[/*last*/].program',
+    name: 'Thread.callers()[/* last */].program',
     src: `
     var callers = Thread.callers();
     typeof callers[callers.length - 1].program;

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -25,52 +25,37 @@ module.exports = [
   // Testcases for TestInterpreterSimple (have expected value):
   {
     name: 'onePlusOne',
-    src: `
-    1 + 1;
-    `,
+    src: `1 + 1;`,
     expected: 2
   },
   {
     name: 'twoPlusTwo',
-    src: `
-    2 + 2;
-    `,
+    src: `2 + 2;`,
     expected: 4
   },
   {
     name: 'sixTimesSeven',
-    src: `
-    6 * 7;
-    `,
+    src: `6 * 7;`,
     expected: 42
   },
   {
     name: 'simpleFourFunction',
-    src: `
-    (3 + 12 / 4) * (10 - 3);
-    `,
+    src: `(3 + 12 / 4) * (10 - 3);`,
     expected: 42
   },
   {
     name: 'variableDecl',
-    src: `
-    var x = 43;
-    x;
-    `,
+    src: `var x = 43; x;`,
     expected: 43
   },
   {
     name: 'condTrue',
-    src: `
-    true ? 'then' : 'else';
-    `,
+    src: `true ? 'then' : 'else';`,
     expected: 'then'
   },
   {
     name: 'condFalse',
-    src: `
-    false ? 'then' : 'else';
-    `,
+    src: `false ? 'then' : 'else';`,
     expected: 'else'
   },
   {
@@ -97,27 +82,17 @@ module.exports = [
   },
   {
     name: 'simpleAssignment',
-    src: `
-    var x = 0;
-    x = 44;
-    x;
-    `,
+    src: `var x = 0; x = 44; x;`,
     expected: 44
   },
   {
     name: 'propertyAssignment',
-    src: `
-    var o = {};
-    o.foo = 45;
-    o.foo;
-    `,
+    src: `var o = {}; o.foo = 45; o.foo;`,
     expected: 45
   },
   {
     name: 'getPropertyOnPrimitive',
-    src: `
-    'foo'.length;
-    `,
+    src: `'foo'.length;`,
     expected: 3
   },
   {
@@ -133,45 +108,27 @@ module.exports = [
   },
   {
     name: 'postincrement',
-    src: `
-    var x = 45;
-    x++;
-    x++;
-    `,
+    src: `var x = 45; x++; x++;`,
     expected: 46
   },
   {
     name: 'preincrement',
-    src: `
-    var x = 45;
-    ++x;
-    ++x;
-    `,
+    src: `var x = 45; ++x; ++x;`,
     expected: 47
   },
   {
     name: 'concat',
-    src: `
-    'foo' + 'bar';
-    `,
+    src: `'foo' + 'bar';`,
     expected: 'foobar'
   },
   {
     name: 'plusequalsLeft',
-    src: `
-    var x = 40, y = 8;
-    x += y;
-    x;
-    `,
+    src: `var x = 40, y = 8; x += y; x;`,
     expected: 48
   },
   {
     name: 'plusequalsRight',
-    src: `
-    var x = 40, y = 8;
-    x += y;
-    y;
-    `,
+    src: `var x = 40, y = 8; x += y; y;`,
     expected: 8
   },
   {
@@ -195,50 +152,37 @@ module.exports = [
   },
   {
     name: 'objectExprSetsAnonFuncName',
-    src: `
-    var o = {myPropFunc: function() {}};
-    o.myPropFunc.name;
-    `,
+    src: `({myPropFunc: function() {}}).myPropFunc.name;`,
     expected: 'myPropFunc'
   },
   {
     name: 'varDeclSetsAnonFuncName',
-    src: `
-    var myVarDeclFunc = function() {};
-    myVarDeclFunc.name;
-    `,
+    src: `var myVarDeclFunc = function() {}; myVarDeclFunc.name;`,
     expected: 'myVarDeclFunc'
   },
   {
     name: 'funExpWithParameter',
-    src: `
-    var v;
-    var f = function(x) { v = x; };
-    f(50);
-    v;
-    `,
+    src: `var v; var f = function(x) { v = x; }; f(50); v;`,
     expected: 50
   },
   {
     name: 'funExpParameterNotShadowedByVar',
-    src: `
-    var f = function(x) { var x; return x; };
-    f(50.1);
-    `,
+    src: `var f = function(x) { var x; return x; }; f(50.1);`,
     expected: 50.1
   },
   {
+    name: 'funExpParameterNotShadowedByVar',
+    src: `var f = function(x) { var x = 50.2; return x; }; f(50.2);`,
+    expected: 50.2
+  },
+  {
     name: 'functionWithReturn',
-    src: `
-    (function(x) { return x; })(51);
-    `,
+    src: `(function(x) { return x; })(51);`,
     expected: 51
   },
   {
     name: 'functionWithoutReturn',
-    src: `
-    (function() {})();
-    `,
+    src: `(function() {})();`,
     expected: undefined
   },
   {
@@ -283,17 +227,13 @@ module.exports = [
   // N.B.: This and next tests have no equivalent in the test DB.
   {
     name: 'throwUnhandledError',
-    src: `
-    throw new Error('not caught');
-    `,
+    src: `throw new Error('not caught');`,
     options: {noLog: ['unhandled']},
     expected: undefined
   },
   {
     name: 'throwUnhandledException',
-    src: `
-    throw 'not caught';
-    `,
+    src: `throw 'not caught';`,
     options: {noLog: ['unhandled']},
     expected: undefined
   },
@@ -321,16 +261,12 @@ module.exports = [
   },
   {
     name: 'seqExpr',
-    src: `
-    51, 52, 53;
-    `,
+    src: `51, 52, 53;`,
     expected: 53
   },
   {
     name: 'labeledStatement',
-    src: `
-    foo: 54;
-    `,
+    src: `foo: 54;`,
     expected: 54
   },
   {
@@ -381,9 +317,7 @@ module.exports = [
   },
   {
     name: 'selfBreak',
-    src: `
-    foo: break foo;
-    `,
+    src: `foo: break foo;`,
     expected: undefined /* (but legal!) */
   },
   {
@@ -451,48 +385,32 @@ module.exports = [
   },
   {
     name: 'orTrue',
-    src: `
-    63 || 'foo';
-    `,
+    src: `63 || 'foo';`,
     expected: 63
   },
   {
     name: 'orFalse',
-    src: `
-    false || 64;
-    `,
+    src: `false || 64;`,
     expected: 64
   },
   {
     name: 'orShortcircuit',
-    src: `
-    var r = 0;
-    true || (r++);
-    r;
-    `,
+    src: `var r = 0; true || (r++); r;`,
     expected: 0
   },
   {
     name: 'andTrue',
-    src: `
-    ({}) && 65;
-    `,
+    src: `({}) && 65;`,
     expected: 65
   },
   {
     name: 'andFalse',
-    src: `
-    0 && 65;
-    `,
+    src: `0 && 65;`,
     expected: 0
   },
   {
     name: 'andShortcircuit',
-    src: `
-    var r = 0;
-    false && (r++);
-    r;
-    `,
+    src: `var r = 0; false && (r++); r;`,
     expected: 0
   },
   {
@@ -613,23 +531,17 @@ module.exports = [
   },
   {
     name: 'thisGlobal',
-    src: `
-    this;
-    `,
+    src: `this;`,
     expected: undefined
   },
   {
     name: 'emptyArrayLength',
-    src: `
-    [].length;
-    `,
+    src: `[].length;`,
     expected: 0
   },
   {
     name: 'arrayElidedLength',
-    src: `
-    [1,,3,,].length;
-    `,
+    src: `[1,,3,,].length;`,
     expected: 4
   },
   {
@@ -760,52 +672,37 @@ module.exports = [
   },
   {
     name: 'compValEmptyBlock',
-    src: `
-    {};
-    `,
+    src: `{};`,
     expected: undefined
   },
   {
     name: 'undefined',
-    src: `
-    undefined;
-    `,
+    src: `undefined;`,
     expected: undefined
   },
   {
     name: 'unaryVoid',
-    src: `
-    var x = 70;
-    (undefined === void x++) && x;
-    `,
+    src: `var x = 70; (undefined === void x++) && x;`,
     expected: 71
   },
   {
     name: 'unaryPlus',
-    src: `
-    +'72';
-    `,
+    src: `+'72';`,
     expected: 72
   },
   {
     name: 'unaryMinus',
-    src: `
-    -73;
-    `,
+    src: `-73;`,
     expected: -73
   },
   {
     name: 'unaryComplement',
-    src: `
-    ~0xffffffb5;
-    `,
+    src: `~0xffffffb5;`,
     expected: 74
   },
   {
     name: 'unaryNot',
-    src: `
-    !false && (!true === false);
-    `,
+    src: `!false && (!true === false);`,
     expected: true
   },
   {
@@ -844,10 +741,7 @@ module.exports = [
   },
   {
     name: 'binaryIn',
-    src: `
-    var o = {foo: 'bar'};
-    'foo' in o && !('bar' in o);
-    `,
+    src: `var o = {foo: 'bar'}; 'foo' in o && !('bar' in o);`,
     expected: true
   },
   {
@@ -861,9 +755,7 @@ module.exports = [
   },
   {
     name: 'binaryInArrayLength',
-    src: `
-    'length' in [];
-    `,
+    src: `'length' in [];`,
     expected: true
   },
   {
@@ -976,10 +868,7 @@ module.exports = [
   },
   {
     name: 'deleteNonexistentFromPrimitive',
-    src: `
-    (delete false.nonexistent) &&
-    (delete (42).toString);
-    `,
+    src: `(delete false.nonexistent) && (delete (42).toString);`,
     expected: true
   },
   // This "actually" tries to delete the non-configurable own .length
@@ -1026,18 +915,12 @@ module.exports = [
   },
   {
     name: 'namedFunExpNameBinding',
-    src: `
-    var f = function foo() {return foo;};
-    f() === f;
-    `,
+    src: `var f = function foo() {return foo;}; f() === f;`,
     expected: true
   },
   {
     name: 'namedFunExpNameBindingNoLeak',
-    src: `
-    var f = function foo() {};
-    typeof foo;
-    `,
+    src: `var f = function foo() {}; typeof foo;`,
     expected: 'undefined'
   },
   {
@@ -1218,17 +1101,12 @@ module.exports = [
   },
   {
     name: 'regexpSimple',
-    src: `
-    /foo/.test('foobar');
-    `,
+    src: `/foo/.test('foobar');`,
     expected: true
   },
   {
     name: 'evalSeeEnclosing',
-    src: `
-    var n = 77.77;
-    eval('n');
-    `,
+    src: `var n = 77.77; eval('n');`,
     expected: 77.77
   },
   {
@@ -1261,27 +1139,17 @@ module.exports = [
   },
   {
     name: 'evalIndirectSeeGlobal',
-    src: `
-    var gEval = eval;
-    gEval('typeof Array');
-    `,
+    src: `var gEval = eval; gEval('typeof Array');`,
     expected: 'function'
   },
   {
     name: 'evalModifyEnclosing',
-    src: `
-    var n = 77.77;
-    eval('n = 77.88');
-    n;
-    `,
+    src: `var n = 77.77; eval('n = 77.88'); n;`,
     expected: 77.88
   },
   {
     name: 'evalNoLeakingDecls',
-    src: `
-    eval('var n = 88.88');
-    typeof n;
-    `,
+    src: `eval('var n = 88.88'); typeof n;`,
     expected: 'undefined'
   },
   // A bug in eval would cause it to return the value of the
@@ -1289,10 +1157,7 @@ module.exports = [
   // not contain any ExpressionStatements.
   {
     name: 'evalEmptyBlock',
-    src: `
-    'fail';
-    eval('{}');
-    `,
+    src: `'fail'; eval('{}');`,
     expected: undefined
   },
   {
@@ -1521,10 +1386,7 @@ module.exports = [
   },
   {
     name: 'Object.create(null) prototype',
-    src: `
-    var o = Object.create(null);
-    Object.getPrototypeOf(o);
-    `,
+    src: `Object.getPrototypeOf(Object.create(null));`,
     expected: null
   },
   {
@@ -1559,11 +1421,8 @@ module.exports = [
     expected: 'TypeError'
   },
   {
-    name: 'Object.getOwnPropertyDescriptor bad keyy',
-    src: `
-    var o = {};
-    Object.getOwnPropertyDescriptor(o, 'foo');
-    `,
+    name: 'Object.getOwnPropertyDescriptor bad key',
+    src: `Object.getOwnPropertyDescriptor({}, 'foo');`,
     expected: undefined
   },
   {
@@ -1604,16 +1463,12 @@ module.exports = [
   },
   {
     name: 'Object.getOwnPropertyNames number',
-    src: `
-    Object.getOwnPropertyNames(42).length
-    `,
+    src: `Object.getOwnPropertyNames(42).length`,
     expected: 0
   },
   {
     name: 'Object.getOwnPropertyNames boolean',
-    src: `
-    Object.getOwnPropertyNames(true).length
-    `,
+    src: `Object.getOwnPropertyNames(true).length`,
     expected: 0
   },
   {
@@ -1736,9 +1591,7 @@ module.exports = [
   },
   {
     name: 'Object.prototype.toString',
-    src: `
-    ({}).toString();
-    `,
+    src: `({}).toString();`,
     expected: '[object Object]'
   },
   {
@@ -1794,17 +1647,12 @@ module.exports = [
   },
   {
     name: 'Object.protoype.isPrototypeOf self',
-    src: `
-    var o = {};
-    o.isPrototypeOf(o);
-    `,
+    src: `var o = {}; o.isPrototypeOf(o);`,
     expected: false
   },
   {
     name: 'Object.protoype.isPrototypeOf unrelated',
-    src: `
-    Object.prototype.isPrototypeOf(Object.create(null))
-    `,
+    src: `Object.prototype.isPrototypeOf(Object.create(null))`,
     expected: false
   },
   {
@@ -1863,72 +1711,52 @@ module.exports = [
   // Function and Function.prototype
   {
     name: 'new Function() returns callable',
-    src: `
-    (new Function)();
-    `,
+    src: `(new Function)();`,
     expected: undefined
   },
   {
     name: 'new Function() .length',
-    src: `
-    (new Function).length;
-    `,
+    src: `(new Function).length;`,
     expected: 0
   },
   {
     name: 'new Function() .toString()',
-    src: `
-    String(new Function)
-    `,
+    src: `(new Function).toString()`,
     expected: 'function() {}'
   },
   {
     name: 'new Function simple returns callable',
-    src: `
-    (new Function('return 42;'))();
-    `,
+    src: `(new Function('return 42;'))();`,
     expected: 42
   },
   {
     name: 'new Function simple .length',
-    src: `
-    (new Function('return 42;')).length;
-    `,
+    src: `(new Function('return 42;')).length;`,
     expected: 0
   },
   {
     name: 'new Function simple .toString()',
-    src: `
-    String(new Function('return 42;'))
-    `,
+    src: `(new Function('return 42;')).toString()`,
     expected: 'function() {return 42;}'
   },
   {
     name: 'new Function with args returns callable',
-    src: `
-    (new Function('a, b', 'c', 'return a + b * c;'))(2, 3, 10);
-    `,
+    src: `(new Function('a, b', 'c', 'return a + b * c;'))(2, 3, 10);`,
     expected: 32
   },
   {
     name: 'new Function with args .length',
-    src: `
-    (new Function('a, b', 'c', 'return a + b * c;')).length;
-    `,
+    src: `(new Function('a, b', 'c', 'return a + b * c;')).length;`,
     expected: 3
   },
   {
     name: 'new Function with args .toString()',
-    src: `
-    String(new Function('a, b', 'c', 'return a + b * c;'))
-    `,
+    src: `String(new Function('a, b', 'c', 'return a + b * c;'))`,
     expected: 'function(a, b,c) {return a + b * c;}'
   },
   {
     name: 'Function.prototype has no .prototype',
-    src: `
-    Function.prototype.hasOwnProperty('prototype');
-    `,
+    src: `Function.prototype.hasOwnProperty('prototype');`,
     expected: false
   },
   {
@@ -2040,10 +1868,7 @@ module.exports = [
   },
   {
     name: 'Function.prototype.call no args',
-    src: `
-    function f() { return arguments.length; }
-    f.call(undefined);
-    `,
+    src: `(function() {return arguments.length;}).call();`,
     expected: 0
   },
   {
@@ -2082,10 +1907,7 @@ module.exports = [
   },
   {
     name: 'Function.prototype.bind no args',
-    src: `
-    function f() { return arguments.length; }
-    f.bind(undefined)();
-    `,
+    src: `(function() { return arguments.length; }).bind()();`,
     expected: 0
   },
   {
@@ -2150,9 +1972,7 @@ module.exports = [
   // N.B.: tests of class constructor semantics unavoidably ES6.
   {
     name: 'Function.protote.bind class constructor',
-    src: `
-    String(new (WeakMap.bind()));
-    `,
+    src: `String(new (WeakMap.bind()));`,
     expected: '[object WeakMap]'
   },
   /////////////////////////////////////////////////////////////////////////////
@@ -2191,30 +2011,22 @@ module.exports = [
   },
   {
     name: 'Array.isArray Array.prototype',
-    src: `
-    Array.isArray(Array.prototype);
-    `,
+    src: `Array.isArray(Array.prototype);`,
     expected: true
   },
   {
     name: 'Array.isArray Array instance',
-    src: `
-    Array.isArray(new Array);
-    `,
+    src: `Array.isArray(new Array);`,
     expected: true
   },
   {
     name: 'Array.isArray array literal',
-    src: `
-    Array.isArray([]);
-    `,
+    src: `Array.isArray([]);`,
     expected: true
   },
   {
     name: 'Array.isArray(array-like)',
-    src: `
-    Array.isArray({0: 'foo', 1: 'bar', length: 2});
-    `,
+    src: `Array.isArray({0: 'foo', 1: 'bar', length: 2});`,
     expected: false
   },
   {
@@ -2246,37 +2058,27 @@ module.exports = [
   },
   {
     name: 'Array.prototype.includes',
-    src: `
-    [1, 2, 3, 2, 1].includes(2);
-    `,
+    src: `[1, 2, 3, 2, 1].includes(2);`,
     expected: true
   },
   {
     name: 'Array.prototype.includes not found',
-    src: `
-    [1, 2, 3, 2, 1].includes(4);
-    `,
+    src: `[1, 2, 3, 2, 1].includes(4);`,
     expected: false
   },
   {
-    name: 'Array.prototype.includes(..., +)',
-    src: `
-    [1, 2, 3, 2, 1].includes(2, 2);
-    `,
+    name: 'Array.prototype.includes fromIndex',
+    src: `[1, 2, 3, 2, 1].includes(2, 2);`,
     expected: true
   },
   {
-    name: 'Array.prototype.includes(..., -)',
-    src: `
-    [1, 2, 3, 2, 1].includes(1, -3);
-    `,
+    name: 'Array.prototype.includes negative fromIndex',
+    src: `[1, 2, 3, 2, 1].includes(1, -3);`,
     expected: true
   },
   {
     name: 'Array.prototype.includes NaN',
-    src: `
-    ['x', NaN, 'y'].includes(NaN);
-    `,
+    src: `['x', NaN, 'y'].includes(NaN);`,
     expected: true
   },
   {
@@ -2289,37 +2091,27 @@ module.exports = [
   },
   {
     name: 'Array.prototype.indexOf',
-    src: `
-    [1, 2, 3, 2, 1].indexOf(2);
-    `,
+    src: `[1, 2, 3, 2, 1].indexOf(2);`,
     expected: 1
   },
   {
     name: 'Array.prototype.indexOf not found',
-    src: `
-    [1, 2, 3, 2, 1].indexOf(4);
-    `,
+    src: `[1, 2, 3, 2, 1].indexOf(4);`,
     expected: -1
   },
   {
     name: 'Array.prototype.indexOf(..., +)',
-    src: `
-    [1, 2, 3, 2, 1].indexOf(2, 2);
-    `,
+    src: `[1, 2, 3, 2, 1].indexOf(2, 2);`,
     expected: 3
   },
   {
     name: 'Array.prototype.indexOf(..., -)',
-    src: `
-    [1, 2, 3, 2, 1].indexOf(1, -3);
-    `,
+    src: `[1, 2, 3, 2, 1].indexOf(1, -3);`,
     expected: 4
   },
   {
     name: 'Array.prototype.indexOf NaN',
-    src: `
-    ['x', NaN, 'y'].indexOf(NaN);
-    `,
+    src: `['x', NaN, 'y'].indexOf(NaN);`,
     expected: -1
   },
   {
@@ -2332,9 +2124,7 @@ module.exports = [
   },
   {
     name: 'Array.prototype.join',
-    src: `
-    [1, 2, 3].join('-');
-    `,
+    src: `[1, 2, 3].join('-');`,
     expected: '1-2-3'
   },
   {
@@ -2349,30 +2139,22 @@ module.exports = [
   },
   {
     name: 'Array.prototype.lastIndexOf',
-    src: `
-    [1, 2, 3, 2, 1].lastIndexOf(2);
-    `,
+    src: `[1, 2, 3, 2, 1].lastIndexOf(2);`,
     expected: 3
   },
   {
     name: 'Array.prototype.lastIndexOf not found',
-    src: `
-    [1, 2, 3, 2, 1].lastIndexOf(4);
-    `,
+    src: `[1, 2, 3, 2, 1].lastIndexOf(4);`,
     expected: -1
   },
   {
     name: 'Array.prototype.lastIndexOf(..., +)',
-    src: `
-    [1, 2, 3, 2, 1].lastIndexOf(2, 2);
-    `,
+    src: `[1, 2, 3, 2, 1].lastIndexOf(2, 2);`,
     expected: 1
   },
   {
     name: 'Array.prototype.lastIndexOf(..., -)',
-    src: `
-    [1, 2, 3, 2, 1].lastIndexOf(1, -3);
-    `,
+    src: `[1, 2, 3, 2, 1].lastIndexOf(1, -3);`,
     expected: 0
   },
   {
@@ -2623,9 +2405,7 @@ module.exports = [
   },
   {
     name: 'Array.prototype.sort()',
-    src: `
-    [5, 2, 3, 1, 4].sort().join();  // Sorts ASCIIbetically.
-    `,
+    src: `[5, 2, 3, 1, 4].sort().join();  // Sorts ASCIIbetically.`,
     expected: '1,2,3,4,5'
   },
   {
@@ -2638,9 +2418,7 @@ module.exports = [
   },
   {
     name: 'Array.prototype.sort(comparefn)',
-    src: `
-    [99, 9, 10, 11, 1, 0, 5].sort(function(a, b) {return a - b;}).join();
-    `,
+    src: `[99, 9, 10, 11, 1, 0, 5].sort(function(a, b) {return a - b;}).join();`,
     expected: '0,1,5,9,10,11,99'
   },
   {
@@ -2729,18 +2507,12 @@ module.exports = [
   },
   {
     name: 'Array.prototype.toString.call(obj-w/join)',
-    src: `
-    var o = {join: function() {return 'OK';}};
-    Array.prototype.toString.apply(o);
-    `,
+    src: `Array.prototype.toString.apply({join: function() {return 'OK';}});`,
     expected: 'OK'
   },
   {
     name: 'Array.prototype.toString.call(array-like)',
-    src: `
-    var o = {0: 'foo', 1: 'bar', length: 2};
-    Array.prototype.toString.apply(o);
-    `,
+    src: `Array.prototype.toString.apply({0: 'foo', 1: 'bar', length: 2});`,
     expected: '[object Object]'
   },
   {
@@ -2806,23 +2578,17 @@ module.exports = [
   },
   {
     name: 'Boolean.prototype.toString()',
-    src: `
-    Boolean.prototype.toString();
-    `,
+    src: `Boolean.prototype.toString();`,
     expected: 'false'
   },
   {
     name: 'Boolean.prototype.toString.call(true)',
-    src: `
-    Boolean.prototype.toString.call(true);
-    `,
+    src: `Boolean.prototype.toString.call(true);`,
     expected: 'true'
   },
   {
     name: 'Boolean.prototype.toString.call(false)',
-    src: `
-    Boolean.prototype.toString.call(false);
-    `,
+    src: `Boolean.prototype.toString.call(false);`,
     expected: 'false'
   },
   {
@@ -2838,18 +2604,18 @@ module.exports = [
   },
   {
     name: 'Boolean.prototype.valueOf()',
-    src: `
-    Boolean.prototype.valueOf();
-    `,
+    src: `Boolean.prototype.valueOf();`,
     expected: false
   },
   {
-    name: 'Boolean.prototype.valueOf.call primitive',
-    src: `
-    Boolean.prototype.valueOf.call(true) &&
-        !Boolean.prototype.valueOf.call(false);
-    `,
+    name: 'Boolean.prototype.valueOf.call primitive true',
+    src: `Boolean.prototype.valueOf.call(true);`,
     expected: true
+  },
+  {
+    name: 'Boolean.prototype.valueOf.call primitive false',
+    src: `Boolean.prototype.valueOf.call(false);`,
+    expected: false
   },
   {
     name: 'Boolean.prototype.valueOf.call non-Boolean object',
@@ -2902,16 +2668,12 @@ module.exports = [
   },
   {
     name: 'Number.prototype.toString()',
-    src: `
-    Number.prototype.toString();
-    `,
+    src: `Number.prototype.toString();`,
     expected: '0'
   },
   {
     name: 'Number.prototype.toString.call primitive',
-    src: `
-    Number.prototype.toString.call(84);
-    `,
+    src: `Number.prototype.toString.call(84);`,
     expected: '84'
   },
   {
@@ -2927,16 +2689,12 @@ module.exports = [
   },
   {
     name: 'Number.prototype.valueOf()',
-    src: `
-    Number.prototype.valueOf();
-    `,
+    src: `Number.prototype.valueOf();`,
     expected: 0
   },
   {
     name: 'Number.prototype.valueOf.call primitive',
-    src: `
-    Number.prototype.valueOf.call(85);
-    `,
+    src: `Number.prototype.valueOf.call(85);`,
     expected: 85
   },
   {
@@ -3098,16 +2856,12 @@ module.exports = [
   },
   {
     name: 'String.prototype.toString()',
-    src: `
-    String.prototype.toString();
-    `,
+    src: `String.prototype.toString();`,
     expected: ''
   },
   {
     name: 'String.prototype.toString.call primitive',
-    src: `
-    String.prototype.toString.call('a string');
-    `,
+    src: `String.prototype.toString.call('a string');`,
     expected: 'a string'
   },
   {
@@ -3123,16 +2877,12 @@ module.exports = [
   },
   {
     name: 'String.prototype.valueOf()',
-    src: `
-    String.prototype.valueOf();
-    `,
+    src: `String.prototype.valueOf();`,
     expected: ''
   },
   {
     name: 'String.prototype.valueOf.call primitive',
-    src: `
-    String.prototype.valueOf.call('a string');
-    `,
+    src: `String.prototype.valueOf.call('a string');`,
     expected: 'a string'
   },
   {
@@ -3241,23 +2991,17 @@ module.exports = [
   },
   {
     name: 'JSON.stringify(function(){})',
-    src: `
-    JSON.stringify(function(){});
-    `,
+    src: `JSON.stringify(function(){});`,
     expected: undefined
   },
   {
     name: 'JSON.stringify([function(){}])',
-    src: `
-    JSON.stringify([function(){}]);
-    `,
+    src: `JSON.stringify([function(){}]);`,
     expected: '[null]'
   },
   {
     name: 'JSON.stringify({f: function(){}})',
-    src: `
-    JSON.stringify({f: function(){}});
-    `,
+    src: `JSON.stringify({f: function(){}});`,
     expected: '{}'
   },
   {
@@ -3301,9 +3045,7 @@ module.exports = [
   },
   {
     name: 'JSON.stringify inherited',
-    src: `
-    JSON.stringify(Object.create({foo: 'bar'}));
-    `,
+    src: `JSON.stringify(Object.create({foo: 'bar'}));`,
     expected: '{}'
   },
   {
@@ -3429,9 +3171,9 @@ module.exports = [
     name: 'Thread.callers()[/*last*/].program',
     src: `
     var callers = Thread.callers();
-    Boolean(callers[callers.length - 1].program);
+    typeof callers[callers.length - 1].program;
     `,
-    expected: true
+    expected: 'string'
   },
   {
     name: 'Thread.callers()[0].callerPerms',
@@ -3451,9 +3193,7 @@ module.exports = [
   // builtins.
   {
     name: 'Thread.prototype.getTimeLimit() initially 0',
-    src: `
-    Thread.current().getTimeLimit();
-    `,
+    src: `Thread.current().getTimeLimit();`,
     expected: 0
   },
   {
@@ -3494,9 +3234,7 @@ module.exports = [
   // Permissions system:
   {
     name: 'perms returns root',
-    src: `
-    perms() === CC.root;
-    `,
+    src: `perms() === CC.root;`,
     expected: true
   },
   {
@@ -3541,9 +3279,7 @@ module.exports = [
   // Other tests:
   {
     name: 'new hack',
-    src: `
-    (new 'Array.prototype.push') === Array.prototype.push
-    `,
+    src: `(new 'Array.prototype.push') === Array.prototype.push`,
     expected: true
   },
   {

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -23,34 +23,13 @@
 
 // Testcases for testSimple in interpreter_test.js.
 module.exports = [
-  {
-    src: `1 + 1;`,
-    expected: 2
-  },
-  {
-    src: `2 + 2;`,
-    expected: 4
-  },
-  {
-    src: `6 * 7;`,
-    expected: 42
-  },
-  {
-    src: `(3 + 12 / 4) * (10 - 3);`,
-    expected: 42
-  },
-  {
-    src: `var x = 43; x;`,
-    expected: 43
-  },
-  {
-    src: `true ? 'then' : 'else';`,
-    expected: 'then'
-  },
-  {
-    src: `false ? 'then' : 'else';`,
-    expected: 'else'
-  },
+  {src: `1 + 1;`, expected: 2},
+  {src: `2 + 2;`, expected: 4},
+  {src: `6 * 7;`, expected: 42},
+  {src: `(3 + 12 / 4) * (10 - 3);`, expected: 42},
+  {src: `var x = 43; x;`, expected: 43},
+  {src: `true ? 'then' : 'else';`, expected: 'then'},
+  {src: `false ? 'then' : 'else';`, expected: 'else'},
   {
     name: 'if(true)',
     src: `
@@ -99,18 +78,9 @@ module.exports = [
     `,
     expected: 'TypeError',
   },
-  {
-    src: `var x = 45; x++; x++;`,
-    expected: 46
-  },
-  {
-    src: `var x = 45; ++x; ++x;`,
-    expected: 47
-  },
-  {
-    src: `'foo' + 'bar';`,
-    expected: 'foobar'
-  },
+  {src: `var x = 45; x++; x++;`, expected: 46},
+  {src: `var x = 45; ++x; ++x;`, expected: 47},
+  {src: `'foo' + 'bar';`, expected: 'foobar'},
   {
     name: 'Effect of += on left argument',
     src: `var x = 40, y = 8; x += y; x;`,
@@ -232,10 +202,7 @@ module.exports = [
     options: {noLog: ['unhandled']},
     expected: undefined
   },
-  {
-    src: `51, 52, 53;`,
-    expected: 53
-  },
+  {src: `51, 52, 53;`, expected: 53},
   {
     name: 'sequenceExpression',
     src: `
@@ -357,27 +324,15 @@ module.exports = [
     `,
     expected: 62,
   },
-  {
-    src: `63 || 'foo';`,
-    expected: 63
-  },
-  {
-    src: `false || 64;`,
-    expected: 64
-  },
+  {src: `63 || 'foo';`, expected: 63},
+  {src: `false || 64;`, expected: 64},
   {
     name: '|| short-circuit',
     src: `var r = 0; true || (r++); r;`,
     expected: 0,
   },
-  {
-    src: `({}) && 65;`,
-    expected: 65
-  },
-  {
-    src: `0 && 65;`,
-    expected: 0
-  },
+  {src: `({}) && 65;`, expected: 65},
+  {src: `0 && 65;`, expected: 0},
   {
     name: '&&  sort-circuit',
     src: `var r = 0; false && (r++); r;`,
@@ -495,14 +450,8 @@ module.exports = [
     src: `this;`,
     expected: undefined,
   },
-  {
-    src: `[].length;`,
-    expected: 0
-  },
-  {
-    src: `[1,,3,,].length;`,
-    expected: 4
-  },
+  {src: `[].length;`, expected: 0},
+  {src: `[1,,3,,].length;`, expected: 4},
   {
     name: 'arrayElidedNotDefinedNotUndefined',
     src: `
@@ -634,31 +583,16 @@ module.exports = [
     src: `{};`,
     expected: undefined,
   },
-  {
-    src: `undefined;`,
-    expected: undefined
-  },
+  {src: `undefined;`, expected: undefined},
   {
     name: 'unaryVoid',
     src: `var x = 70; (undefined === void x++) && x;`,
     expected: 71,
   },
-  {
-    src: `+'72';`,
-    expected: 72
-  },
-  {
-    src: `-73;`,
-    expected: -73
-  },
-  {
-    src: `~0xffffffb5;`,
-    expected: 74
-  },
-  {
-    src: `!false && (!true === false);`,
-    expected: true
-  },
+  {src: `+'72';`, expected: 72},
+  {src: `-73;`, expected: -73},
+  {src: `~0xffffffb5;`, expected: 74},
+  {src: `!false && (!true === false);`, expected: true},
   {
     name: 'unaryTypeof',
     src: `
@@ -707,10 +641,7 @@ module.exports = [
     `,
     expected: true,
   },
-  {
-    src: `'length' in [];`,
-    expected: true
-  },
+  {src: `'length' in [];`, expected: true},
   {
     name: 'binaryInStringLength',
     src: `
@@ -1017,10 +948,7 @@ module.exports = [
     `,
     expected: '[object Arguments]',
   },
-  {
-    src: `debugger;`,
-    expected: undefined
-  },
+  {src: `debugger;`, expected: undefined},
   {
     name: 'newExpression',
     src: `
@@ -1049,10 +977,7 @@ module.exports = [
     `,
     expected: 'the prototype',
   },
-  {
-    src: `/foo/.test('foobar');`,
-    expected: true
-  },
+  {src: `/foo/.test('foobar');`, expected: true},
   {
     name: 'evalSeeEnclosing',
     src: `var n = 77.77; eval('n');`,
@@ -1410,14 +1335,8 @@ module.exports = [
     `,
     expected: 16,
   },
-  {
-    src: `Object.getOwnPropertyNames(42).length`,
-    expected: 0
-  },
-  {
-    src: `Object.getOwnPropertyNames(true).length`,
-    expected: 0
-  },
+  {src: `Object.getOwnPropertyNames(42).length`, expected: 0},
+  {src: `Object.getOwnPropertyNames(true).length`, expected: 0},
   {
     name: 'Object.getOwnPropertyNames(null)',
     src: `
@@ -1598,10 +1517,7 @@ module.exports = [
     src: `var o = {}; o.isPrototypeOf(o);`,
     expected: false,
   },
-  {
-    src: `Object.prototype.isPrototypeOf(Object.create(null))`,
-    expected: false
-  },
+  {src: `Object.prototype.isPrototypeOf(Object.create(null))`, expected: false},
   {
     name: 'Object.protoype.isPrototypeOf related',
     src: `
@@ -1661,23 +1577,14 @@ module.exports = [
     src: `(new Function)();`,
     expected: undefined,
   },
-  {
-    src: `(new Function).length;`,
-    expected: 0
-  },
-  {
-    src: `(new Function).toString()`,
-    expected: 'function() {}'
-  },
+  {src: `(new Function).length;`, expected: 0},
+  {src: `(new Function).toString()`, expected: 'function() {}'},
   {
     name: 'new Function simple returns callable',
     src: `(new Function('return 42;'))();`,
     expected: 42,
   },
-  {
-    src: `(new Function('return 42;')).length;`,
-    expected: 0
-  },
+  {src: `(new Function('return 42;')).length;`, expected: 0},
   {
     src: `(new Function('return 42;')).toString()`,
     expected: 'function() {return 42;}'
@@ -1949,22 +1856,10 @@ module.exports = [
     `,
     expected: '1,2,3',
   },
-  {
-    src: `Array.isArray(Array.prototype);`,
-    expected: true
-  },
-  {
-    src: `Array.isArray(new Array);`,
-    expected: true
-  },
-  {
-    src: `Array.isArray([]);`,
-    expected: true
-  },
-  {
-    src: `Array.isArray({0: 'foo', 1: 'bar', length: 2});`,
-    expected: false
-  },
+  {src: `Array.isArray(Array.prototype);`, expected: true},
+  {src: `Array.isArray(new Array);`, expected: true},
+  {src: `Array.isArray([]);`, expected: true},
+  {src: `Array.isArray({0: 'foo', 1: 'bar', length: 2});`, expected: false},
   {
     name: 'Array.prototype.concat()',
     src: `
@@ -1992,14 +1887,8 @@ module.exports = [
     `,
     expected: '[object Object],baz,,quux,quuux',
   },
-  {
-    src: `[1, 2, 3, 2, 1].includes(2);`,
-    expected: true
-  },
-  {
-    src: `[1, 2, 3, 2, 1].includes(4);`,
-    expected: false
-  },
+  {src: `[1, 2, 3, 2, 1].includes(2);`, expected: true},
+  {src: `[1, 2, 3, 2, 1].includes(4);`, expected: false},
   {
     name: 'Array.prototype.includes fromIndex',
     src: `[1, 2, 3, 2, 1].includes(2, 2);`,
@@ -2010,10 +1899,7 @@ module.exports = [
     src: `[1, 2, 3, 2, 1].includes(1, -3);`,
     expected: true,
   },
-  {
-    src: `['x', NaN, 'y'].includes(NaN);`,
-    expected: true
-  },
+  {src: `['x', NaN, 'y'].includes(NaN);`, expected: true},
   {
     name: 'Array.prototype.includes.call(array-like, ...)',
     src: `
@@ -2512,18 +2398,9 @@ module.exports = [
     `,
     expected: 'pass',
   },
-  {
-    src: `Boolean.prototype.toString();`,
-    expected: 'false'
-  },
-  {
-    src: `Boolean.prototype.toString.call(true);`,
-    expected: 'true'
-  },
-  {
-    src: `Boolean.prototype.toString.call(false);`,
-    expected: 'false'
-  },
+  {src: `Boolean.prototype.toString();`, expected: 'false'},
+  {src: `Boolean.prototype.toString.call(true);`, expected: 'true'},
+  {src: `Boolean.prototype.toString.call(false);`, expected: 'false'},
   {
     name: 'Boolean.prototype.toString.call non-Boolean object',
     src: `
@@ -2535,18 +2412,9 @@ module.exports = [
     `,
     expected: 'TypeError',
   },
-  {
-    src: `Boolean.prototype.valueOf();`,
-    expected: false
-  },
-  {
-    src: `Boolean.prototype.valueOf.call(true);`,
-    expected: true
-  },
-  {
-    src: `Boolean.prototype.valueOf.call(false);`,
-    expected: false
-  },
+  {src: `Boolean.prototype.valueOf();`, expected: false},
+  {src: `Boolean.prototype.valueOf.call(true);`, expected: true},
+  {src: `Boolean.prototype.valueOf.call(false);`, expected: false},
   {
     name: 'Boolean.prototype.valueOf.call non-Boolean object',
     src: `
@@ -2596,14 +2464,8 @@ module.exports = [
     `,
     expected: true,
   },
-  {
-    src: `Number.prototype.toString();`,
-    expected: '0'
-  },
-  {
-    src: `Number.prototype.toString.call(84);`,
-    expected: '84'
-  },
+  {src: `Number.prototype.toString();`, expected: '0'},
+  {src: `Number.prototype.toString.call(84);`, expected: '84'},
   {
     name: 'Number.prototype.toString.call non-Number object',
     src: `
@@ -2615,14 +2477,8 @@ module.exports = [
     `,
     expected: 'TypeError',
   },
-  {
-    src: `Number.prototype.valueOf();`,
-    expected: 0
-  },
-  {
-    src: `Number.prototype.valueOf.call(85);`,
-    expected: 85
-  },
+  {src: `Number.prototype.valueOf();`, expected: 0},
+  {src: `Number.prototype.valueOf.call(85);`, expected: 85},
   {
     name: 'Number.prototype.valueOf.call non-Number object',
     src: `
@@ -2727,10 +2583,7 @@ module.exports = [
     `,
     expected: 'TypeError',
   },
-  {
-    src: `String.prototype.length;`,
-    expected: 0
-  },
+  {src: `String.prototype.length;`, expected: 0},
   {
     name: 'String.prototype.replace(string, string)',
     src: `'xxxx'.replace('xx', 'y');`,
@@ -2779,10 +2632,7 @@ module.exports = [
     src: `'hello'.search(/(.)\\1/)`,
     expected: 2,
   },
-  {
-    src: `String.prototype.toString();`,
-    expected: ''
-  },
+  {src: `String.prototype.toString();`, expected: ''},
   {
     name: 'String.prototype.toString.call primitive',
     src: `String.prototype.toString.call('a string');`,
@@ -2799,10 +2649,7 @@ module.exports = [
     `,
     expected: 'TypeError',
   },
-  {
-    src: `String.prototype.valueOf();`,
-    expected: ''
-  },
+  {src: `String.prototype.valueOf();`, expected: ''},
   {
     name: 'String.prototype.valueOf.call primitive',
     src: `String.prototype.valueOf.call('a string');`,
@@ -2912,18 +2759,9 @@ module.exports = [
     expected: '{"string":"foo","number":42,"true":true,"false":false,' +
         '"null":null,"object":{"obj":{},"arr":[]},"array":[{},[]]}',
   },
-  {
-    src: `JSON.stringify(function(){});`,
-    expected: undefined
-  },
-  {
-    src: `JSON.stringify([function(){}]);`,
-    expected: '[null]'
-  },
-  {
-    src: `JSON.stringify({f: function(){}});`,
-    expected: '{}'
-  },
+  {src: `JSON.stringify(function(){});`, expected: undefined},
+  {src: `JSON.stringify([function(){}]);`, expected: '[null]'},
+  {src: `JSON.stringify({f: function(){}});`, expected: '{}'},
   {
     name: 'JSON.stringify filter',
     src: `
@@ -3191,7 +3029,7 @@ module.exports = [
   },
   {
     name: 'setOwnerOf',
-      src: `
+    src: `
       var bob = {};
       var obj = {};
       Object.setOwnerOf(obj, bob) === obj && Object.getOwnerOf(obj) === bob;

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -60,7 +60,7 @@ module.exports = [
         'else';
       }
     `,
-    expected: 'then'
+    expected: 'then',
   },
   {
     name: 'if(false)',
@@ -71,22 +71,22 @@ module.exports = [
         'else';
       }
     `,
-    expected: 'else'
+    expected: 'else',
   },
   {
     name: 'simpleAssignment',
     src: `var x = 0; x = 44; x;`,
-    expected: 44
+    expected: 44,
   },
   {
     name: 'propertyAssignment',
     src: `var o = {}; o.foo = 45; o.foo;`,
-    expected: 45
+    expected: 45,
   },
   {
     name: 'getPropertyOnPrimitive',
     src: `'foo'.length;`,
-    expected: 3
+    expected: 3,
   },
   {
     name: 'setPropertyOnPrimitive',
@@ -97,7 +97,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     src: `var x = 45; x++; x++;`,
@@ -114,12 +114,12 @@ module.exports = [
   {
     name: 'Effect of += on left argument',
     src: `var x = 40, y = 8; x += y; x;`,
-    expected: 48
+    expected: 48,
   },
   {
     name: 'Effect of += on right argument',
     src: `var x = 40, y = 8; x += y; y;`,
-    expected: 8
+    expected: 8,
   },
   {
     src: `var v, f = function() {v = 49;}; f(); v;
@@ -133,42 +133,42 @@ module.exports = [
       myAssignedFunc = function() {};
       myAssignedFunc.name;
     `,
-    expected: 'myAssignedFunc'
+    expected: 'myAssignedFunc',
   },
   {
     name: 'objectExprSetsAnonFuncName',
     src: `({myPropFunc: function() {}}).myPropFunc.name;`,
-    expected: 'myPropFunc'
+    expected: 'myPropFunc',
   },
   {
     name: 'varDeclSetsAnonFuncName',
     src: `var myVarDeclFunc = function() {}; myVarDeclFunc.name;`,
-    expected: 'myVarDeclFunc'
+    expected: 'myVarDeclFunc',
   },
   {
     name: 'funExpWithParameter',
     src: `var v; var f = function(x) {v = x;}; f(50); v;`,
-    expected: 50
+    expected: 50,
   },
   {
     name: 'funExpParameterNotShadowedByVar',
     src: `var f = function(x) {var x; return x;}; f(50.1);`,
-    expected: 50.1
+    expected: 50.1,
   },
   {
     name: 'funExpParameterNotShadowedByVar',
     src: `var f = function(x) {var x = 50.2; return x;}; f(50.2);`,
-    expected: 50.2
+    expected: 50.2,
   },
   {
     name: 'functionWithReturn',
     src: `(function(x) {return x;})(51);`,
-    expected: 51
+    expected: 51,
   },
   {
     name: 'functionWithoutReturn',
     src: `(function() {})();`,
-    expected: undefined
+    expected: undefined,
   },
   {
     name: 'multipleReturn',
@@ -182,7 +182,7 @@ module.exports = [
       }
       f();
     `,
-    expected: false
+    expected: false,
   },
   {
     name: 'throwCatch',
@@ -196,7 +196,7 @@ module.exports = [
         e * 2;
       }
     `,
-    expected: 52
+    expected: 52,
   },
   {
     name: 'throwCatchFalsey',
@@ -207,20 +207,20 @@ module.exports = [
         'caught ' + String(e);
       }
     `,
-    expected: 'caught null'
+    expected: 'caught null',
   },
   // N.B.: This and next tests have no equivalent in the test DB.
   {
     name: 'throwUnhandledError',
     src: `throw new Error('not caught');`,
     options: {noLog: ['unhandled']},
-    expected: undefined
+    expected: undefined,
   },
   {
     name: 'throwUnhandledException',
     src: `throw 'not caught';`,
     options: {noLog: ['unhandled']},
-    expected: undefined
+    expected: undefined,
   },
   {
     src: `try {throw new Error('not caught');} finally {}`,
@@ -243,12 +243,12 @@ module.exports = [
       x = (y = 60, z = 5, 0.5);
       x + y + z;
     `,
-    expected: 65.5
+    expected: 65.5,
   },
   {
     name: 'labeledStatement',
     src: `foo: 54;`,
-    expected: 54
+    expected: 54,
   },
   {
     name: 'whileLoop',
@@ -257,7 +257,7 @@ module.exports = [
       while (a < 55) a++;
       a;
     `,
-    expected: 55
+    expected: 55,
   },
   {
     name: 'while(false)',
@@ -266,7 +266,7 @@ module.exports = [
       while (false) a++;
       a;
     `,
-    expected: 56
+    expected: 56,
   },
   {
     name: 'do ... while(false)',
@@ -275,7 +275,7 @@ module.exports = [
       do a++; while (false);
       a;
     `,
-    expected: 57
+    expected: 57,
   },
   {
     name: 'do ... break ... while',
@@ -288,7 +288,7 @@ module.exports = [
       } while (false);
       a;
     `,
-    expected: 58
+    expected: 58,
   },
   {
     src: `foo: break foo;`,
@@ -308,7 +308,7 @@ module.exports = [
       }
       a;
     `,
-    expected: 59
+    expected: 59,
   },
   {
     name: 'do ... while with try ... continue ... finally ...',
@@ -323,7 +323,7 @@ module.exports = [
       } while (false);
       a;
     `,
-    expected: 60
+    expected: 60,
   },
   {
     name: 'while with try ... break ... finally continue',
@@ -338,7 +338,7 @@ module.exports = [
       }
       a;
     `,
-    expected: 61
+    expected: 61,
   },
   {
     name: 'while with try ... return ... finally continue',
@@ -355,7 +355,7 @@ module.exports = [
         return i;
       })();
     `,
-    expected: 62
+    expected: 62,
   },
   {
     src: `63 || 'foo';`,
@@ -368,7 +368,7 @@ module.exports = [
   {
     name: '|| short-circuit',
     src: `var r = 0; true || (r++); r;`,
-    expected: 0
+    expected: 0,
   },
   {
     src: `({}) && 65;`,
@@ -381,7 +381,7 @@ module.exports = [
   {
     name: '&&  sort-circuit',
     src: `var r = 0; false && (r++); r;`,
-    expected: 0
+    expected: 0,
   },
   {
     name: 'for',
@@ -392,7 +392,7 @@ module.exports = [
       }
       t;
     `,
-    expected: 66
+    expected: 66,
   },
   {
     name: 'forIn',
@@ -401,7 +401,7 @@ module.exports = [
       for (var i in a) {x += a[i];}
       x;
     `,
-    expected: 67
+    expected: 67,
   },
   {
     name: 'forInMemberExp',
@@ -410,7 +410,7 @@ module.exports = [
       for (o.foo in a) {x *= a[o.foo];}
       x;
     `,
-    expected: 68
+    expected: 68,
   },
   {
     name: 'forInMembFunc',
@@ -421,7 +421,7 @@ module.exports = [
       for (f().foo in a) {x += a[o.foo];}
       x;
     `,
-    expected: 69
+    expected: 69,
   },
   {
     name: 'forInNullUndefined',
@@ -432,7 +432,7 @@ module.exports = [
       for (f().foo in undefined) {x++;}
       x;
     `,
-    expected: 0
+    expected: 0,
   },
   {
     name: 'switchDefaultFirst',
@@ -445,7 +445,7 @@ module.exports = [
           'fail';
       };
     `,
-    expected: 'OK'
+    expected: 'OK',
   },
   {
     name: 'switchDefaultOnly',
@@ -455,7 +455,7 @@ module.exports = [
           'OK';
       };
     `,
-    expected: 'OK'
+    expected: 'OK',
   },
   {
     name: 'switchEmptyToEnd',
@@ -468,7 +468,7 @@ module.exports = [
         case 'bar':
       };
     `,
-    expected: 'ok'
+    expected: 'ok',
   },
   {
     name: 'thisInMethod',
@@ -479,7 +479,7 @@ module.exports = [
       };
       o.f();
     `,
-    expected: 70
+    expected: 70,
   },
   {
     name: 'thisInFormerMethod',
@@ -488,12 +488,12 @@ module.exports = [
       var g = o.f;
       g();
     `,
-    expected: undefined
+    expected: undefined,
   },
   {
     name: 'thisGlobal',
     src: `this;`,
-    expected: undefined
+    expected: undefined,
   },
   {
     src: `[].length;`,
@@ -509,7 +509,7 @@ module.exports = [
       var a = [,undefined,null,0,false];
       !(0 in a) && (1 in a) && (2 in a) && (3 in a) && (4 in a);
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'arrayLengthPropertyDescriptor',
@@ -518,7 +518,7 @@ module.exports = [
       var pd = Object.getOwnPropertyDescriptor(a, 'length');
       (pd.value === 3) && pd.writable && !pd.enumerable && !pd.configurable;
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'arrayLength',
@@ -602,7 +602,7 @@ module.exports = [
         String(e);
       }
     `,
-    expected: 'OK'
+    expected: 'OK',
   },
   {
     name: 'arrayLengthWithNonWritableProps',
@@ -613,7 +613,7 @@ module.exports = [
       a.length = 0;
       a[0] === undefined && a.length === 0;
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'arrayLengthWithNonConfigurableProps',
@@ -627,12 +627,12 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'compValEmptyBlock',
     src: `{};`,
-    expected: undefined
+    expected: undefined,
   },
   {
     src: `undefined;`,
@@ -641,7 +641,7 @@ module.exports = [
   {
     name: 'unaryVoid',
     src: `var x = 70; (undefined === void x++) && x;`,
-    expected: 71
+    expected: 71,
   },
   {
     src: `+'72';`,
@@ -680,7 +680,7 @@ module.exports = [
       }
       (ok === tests.length) ? 'pass' : 'fail';
     `,
-    expected: 'pass'
+    expected: 'pass',
   },
   {
     name: 'unaryTypeofUndeclared',
@@ -691,12 +691,12 @@ module.exports = [
         'whoops!'
       }
     `,
-    expected: 'undefined'
+    expected: 'undefined',
   },
   {
     name: 'binaryIn',
     src: `var o = {foo: 'bar'}; 'foo' in o && !('bar' in o);`,
-    expected: true
+    expected: true,
   },
   {
     name: 'binaryInParent',
@@ -705,7 +705,7 @@ module.exports = [
       var o = Object.create(p);
       'foo' in o && !('bar' in o);
     `,
-    expected: true
+    expected: true,
   },
   {
     src: `'length' in [];`,
@@ -720,7 +720,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'instanceofBasics',
@@ -729,7 +729,7 @@ module.exports = [
       var f = new F;
       f instanceof F && f instanceof Object && !(f.prototype instanceof F);
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'instanceofNonObjectLHS',
@@ -738,7 +738,7 @@ module.exports = [
       F.prototype = null;
       42 instanceof F;
     `,
-    expected: false
+    expected: false,
   },
   {
     name: 'instanceofNonFunctionRHS',
@@ -749,7 +749,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'instanceofNonObjectPrototype',
@@ -762,7 +762,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'undefined.foo',
@@ -773,7 +773,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'undefined.foo = ...',
@@ -785,7 +785,7 @@ module.exports = [
         e.name + ',' + c;
       }
     `,
-    expected: 'TypeError,0'
+    expected: 'TypeError,0',
   },
   {
     name: 'null.foo',
@@ -796,7 +796,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'null.foo = ...',
@@ -808,7 +808,7 @@ module.exports = [
         e.name + ',' + c;
       }
     `,
-    expected: 'TypeError,0'
+    expected: 'TypeError,0',
   },
   {
     name: 'delete',
@@ -817,12 +817,12 @@ module.exports = [
       (delete o.quux) + ('foo' in o) + (delete o.foo) +
           !('foo' in o) + (delete o.foo);
     `,
-    expected: 5
+    expected: 5,
   },
   {
     name: 'deleteNonexistentFromPrimitive',
     src: `(delete false.nonexistent) && (delete (42).toString);`,
-    expected: true
+    expected: true,
   },
   // This "actually" tries to delete the non-configurable own .length
   // property from the auto-boxed String instance created by step 4a
@@ -839,7 +839,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'funcDecl',
@@ -851,7 +851,7 @@ module.exports = [
       f();
       v;
     `,
-    expected: 75
+    expected: 75,
   },
   {
     name: 'namedFunctionExpression',
@@ -864,17 +864,17 @@ module.exports = [
       };
       f(152)
     `,
-    expected: 76
+    expected: 76,
   },
   {
     name: 'namedFunExpNameBinding',
     src: `var f = function foo() {return foo;}; f() === f;`,
-    expected: true
+    expected: true,
   },
   {
     name: 'namedFunExpNameBindingNoLeak',
     src: `var f = function foo() {}; typeof foo;`,
-    expected: 'undefined'
+    expected: 'undefined',
   },
   {
     name: 'namedFunExpNameBindingImmutable',
@@ -888,7 +888,7 @@ module.exports = [
       };
       f();
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'namedFunExpNameBindingShadowedByParam',
@@ -899,7 +899,7 @@ module.exports = [
       };
       f(76);
     `,
-    expected: 76.1
+    expected: 76.1,
   },
   {
     name: 'namedFunExpNameBindingShadowedByVar',
@@ -911,7 +911,7 @@ module.exports = [
       };
       f();
     `,
-    expected: 76.2
+    expected: 76.2,
   },
   {
     name: 'closureIndependence',
@@ -923,7 +923,7 @@ module.exports = [
       var plus4 = makeAdder(4);
       plus3(plus4(70));
     `,
-    expected: 77
+    expected: 77,
   },
   {
     name: 'internalObjectToString',
@@ -934,7 +934,7 @@ module.exports = [
         key;
       }
     `,
-    expected: '[object Object]'
+    expected: '[object Object]',
   },
   {
     name: 'internalFunctionToString',
@@ -946,7 +946,7 @@ module.exports = [
       }
       /^function.*\(.*\).*{[^]*}$/.test(s);
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'internalNativeFuncToString',
@@ -958,7 +958,7 @@ module.exports = [
       }
       /^function.*\(.*\).*{[^]*}$/.test(s);
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'internalArrayToString',
@@ -969,7 +969,7 @@ module.exports = [
         key;
       }
     `,
-    expected: '1,2,3'
+    expected: '1,2,3',
   },
   {
     name: 'internalDateToString',
@@ -980,7 +980,7 @@ module.exports = [
         key;
       }
     `,
-    expected: (new Date(0)).toString()
+    expected: (new Date(0)).toString(),
   },
   {
     name: 'internalRegExpToString',
@@ -991,7 +991,7 @@ module.exports = [
         key;
       }
     `,
-    expected: '/foo/g'
+    expected: '/foo/g',
   },
   {
     name: 'internalErrorToString',
@@ -1002,7 +1002,7 @@ module.exports = [
         key;
       }
     `,
-    expected: 'Error: oops'
+    expected: 'Error: oops',
   },
   {
     name: 'internalArgumentsToString',
@@ -1015,7 +1015,7 @@ module.exports = [
         key;
       }
     `,
-    expected: '[object Arguments]'
+    expected: '[object Arguments]',
   },
   {
     src: `debugger;`,
@@ -1029,7 +1029,7 @@ module.exports = [
       var t = new T(7, 0.7);
       t.sum;
     `,
-    expected: 77.7
+    expected: 77.7,
   },
   {
     name: 'newExpressionReturnObj',
@@ -1038,7 +1038,7 @@ module.exports = [
       T.prototype = {p: 'the prototype'};
       (new T).p;
     `,
-    expected: undefined
+    expected: undefined,
   },
   {
     name: 'newExpressionReturnPrimitive',
@@ -1047,7 +1047,7 @@ module.exports = [
       T.prototype = {p: 'the prototype'};
       (new T).p;
     `,
-    expected: 'the prototype'
+    expected: 'the prototype',
   },
   {
     src: `/foo/.test('foobar');`,
@@ -1056,7 +1056,7 @@ module.exports = [
   {
     name: 'evalSeeEnclosing',
     src: `var n = 77.77; eval('n');`,
-    expected: 77.77
+    expected: 77.77,
   },
   {
     name: 'evalIndirectNoSeeEnclosing',
@@ -1070,7 +1070,7 @@ module.exports = [
         }
       })();
     `,
-    expected: 'ReferenceError'
+    expected: 'ReferenceError',
   },
   {
     name: 'evalIndirectNoSeeEnclosing2',
@@ -1084,22 +1084,22 @@ module.exports = [
         }
       })();
     `,
-    expected: 'ReferenceError'
+    expected: 'ReferenceError',
   },
   {
     name: 'evalIndirectSeeGlobal',
     src: `var gEval = eval; gEval('typeof Array');`,
-    expected: 'function'
+    expected: 'function',
   },
   {
     name: 'evalModifyEnclosing',
     src: `var n = 77.77; eval('n = 77.88'); n;`,
-    expected: 77.88
+    expected: 77.88,
   },
   {
     name: 'evalNoLeakingDecls',
     src: `eval('var n = 88.88'); typeof n;`,
-    expected: 'undefined'
+    expected: 'undefined',
   },
   // A bug in eval would cause it to return the value of the
   // previously-evaluated ExpressionStatement if the eval program did
@@ -1107,7 +1107,7 @@ module.exports = [
   {
     name: 'evalEmptyBlock',
     src: `'fail'; eval('{}');`,
-    expected: undefined
+    expected: undefined,
   },
   {
     name: 'callEvalOrder',
@@ -1120,7 +1120,7 @@ module.exports = [
       (log('f'))(log('a'), log('b'), log('c'));
       r;
     `,
-    expected: 'fabc'
+    expected: 'fabc',
   },
   {
     name: 'callEvalArgsBeforeCallability',
@@ -1133,7 +1133,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'args'
+    expected: 'args',
   },
   {
     name: 'callNonCallable',
@@ -1159,7 +1159,7 @@ module.exports = [
       }
       (ok === tests.length) ? 'pass' : 'fail';
     `,
-    expected: 'pass'
+    expected: 'pass',
   },
   /////////////////////////////////////////////////////////////////////////////
   // Object and Object.prototype
@@ -1172,7 +1172,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.defineProperty non-object',
@@ -1183,7 +1183,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.defineProperty bad descriptor',
@@ -1195,7 +1195,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   // This also tests iteration over (non-)enumerable properties.
   {
@@ -1227,7 +1227,7 @@ module.exports = [
       r += Object.getOwnPropertyNames(o).length;
       r;
     `,
-    expected: 78
+    expected: 78,
   },
   {
     name: 'Object.getPrototypeOf(null) and undefined',
@@ -1242,7 +1242,7 @@ module.exports = [
       }
       r;
     `,
-    expected: 'TypeErrorTypeError'
+    expected: 'TypeErrorTypeError',
   },
   // This tests for ES6 behaviour:
   {
@@ -1252,7 +1252,7 @@ module.exports = [
       Object.getPrototypeOf(1337) === Number.prototype &&
       Object.getPrototypeOf('hi') === String.prototype;
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Object.setPrototypeOf(null, ...) and undefined',
@@ -1267,7 +1267,7 @@ module.exports = [
       }
       r;
     `,
-    expected: 'TypeErrorTypeError'
+    expected: 'TypeErrorTypeError',
   },
   {
     name: 'Object.setPrototypeOf primitives',
@@ -1276,7 +1276,7 @@ module.exports = [
       Object.setPrototypeOf(1337, null) === 1337 &&
       Object.setPrototypeOf('hi', null) === 'hi';
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Object.setPrototypeOf',
@@ -1287,7 +1287,7 @@ module.exports = [
       Object.setPrototypeOf(q, p) === q &&
           Object.getPrototypeOf(q) === p && q.parent;
     `,
-    expected: 'p'
+    expected: 'p',
   },
   {
     name: 'Object.setPrototypeOf(..., null)',
@@ -1296,7 +1296,7 @@ module.exports = [
       var q = Object.create(o);
       Object.setPrototypeOf(q, null) === q && Object.getPrototypeOf(q);
     `,
-    expected: null
+    expected: null,
   },
   {
     name: 'Object.setPrototypeOf circular',
@@ -1309,7 +1309,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.create()',
@@ -1320,7 +1320,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.create non-object prototype',
@@ -1331,12 +1331,12 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.create(null) prototype',
     src: `Object.getPrototypeOf(Object.create(null));`,
-    expected: null
+    expected: null,
   },
   {
     name: 'Object.create',
@@ -1345,7 +1345,7 @@ module.exports = [
       delete o.foo
       o.foo;
     `,
-    expected: 79
+    expected: 79,
   },
   {
     name: 'Object.getOwnPropertyDescriptor()',
@@ -1356,7 +1356,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.getOwnPropertyDescriptor non-object',
@@ -1367,12 +1367,12 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.getOwnPropertyDescriptor bad key',
     src: `Object.getOwnPropertyDescriptor({}, 'foo');`,
-    expected: undefined
+    expected: undefined,
   },
   {
     name: 'Object.getOwnPropertyDescriptor',
@@ -1383,7 +1383,7 @@ module.exports = [
       desc.value === o.foo &&
           !desc.writable && !desc.enumerable && !desc.configurable;
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Object.getOwnPropertyNames()',
@@ -1394,7 +1394,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.getOwnPropertyNames string',
@@ -1408,7 +1408,7 @@ module.exports = [
         }
       }
     `,
-    expected: 16
+    expected: 16,
   },
   {
     src: `Object.getOwnPropertyNames(42).length`,
@@ -1427,7 +1427,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.getOwnPropertyNames(undefined)',
@@ -1438,7 +1438,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.getOwnPropertyNames',
@@ -1453,7 +1453,7 @@ module.exports = [
       }
       r;
     `,
-    expected: 80
+    expected: 80,
   },
   {
     name: 'Object.defineProperties()',
@@ -1464,7 +1464,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.defineProperties non-object',
@@ -1475,7 +1475,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.defineProperties non-object props',
@@ -1486,7 +1486,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.defineProperties bad descriptor',
@@ -1498,7 +1498,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.defineProperties',
@@ -1516,7 +1516,7 @@ module.exports = [
       }
       r + Object.getOwnPropertyNames(o).length;
     `,
-    expected: 81
+    expected: 81,
   },
   {
     name: 'Object.create(..., properties)',
@@ -1534,12 +1534,12 @@ module.exports = [
       }
       r + Object.getOwnPropertyNames(o).length;
     `,
-    expected: 82
+    expected: 82,
   },
   {
     name: 'Object.prototype.toString',
     src: `({}).toString();`,
-    expected: '[object Object]'
+    expected: '[object Object]',
   },
   {
     name: 'Object.protoype.hasOwnProperty',
@@ -1554,7 +1554,7 @@ module.exports = [
       }
       r;
     `,
-    expected: 83
+    expected: 83,
   },
   {
     name: 'Object.protoype.isPrototypeOf primitives',
@@ -1568,7 +1568,7 @@ module.exports = [
       Object.prototype.isPrototypeOf.call(null, null) ||
       Object.prototype.isPrototypeOf.call(undefined, undefined);
     `,
-    expected: false
+    expected: false,
   },
   {
     name: 'Object.protoype.isPrototypeOf.call(null, ...)',
@@ -1579,7 +1579,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.protoype.isPrototypeOf.call(undefined, ...)',
@@ -1591,12 +1591,12 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.protoype.isPrototypeOf self',
     src: `var o = {}; o.isPrototypeOf(o);`,
-    expected: false
+    expected: false,
   },
   {
     src: `Object.prototype.isPrototypeOf(Object.create(null))`,
@@ -1612,7 +1612,7 @@ module.exports = [
       g.isPrototypeOf(o) && p.isPrototypeOf(o) &&
       !o.isPrototypeOf(p) && !o.isPrototypeOf(g);
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Object.protoype.propertyIsEnumerable(null)',
@@ -1623,7 +1623,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'ObjectProtoypePropertyIsEnumerableUndefined',
@@ -1634,7 +1634,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Object.protoype.propertyIsEnumerable primitives',
@@ -1642,7 +1642,7 @@ module.exports = [
       var OppIE = Object.prototype.propertyIsEnumerable;
       OppIE.call('foo', '0') && !OppIE.call('foo', 'length');
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Object.protoype.propertyIsEnumerable',
@@ -1652,14 +1652,14 @@ module.exports = [
       o.propertyIsEnumerable('foo') && !o.propertyIsEnumerable('bar') &&
           !o.propertyIsEnumerable('baz');
     `,
-    expected: true
+    expected: true,
   },
   /////////////////////////////////////////////////////////////////////////////
   // Function and Function.prototype
   {
     name: 'new Function() returns callable',
     src: `(new Function)();`,
-    expected: undefined
+    expected: undefined,
   },
   {
     src: `(new Function).length;`,
@@ -1672,7 +1672,7 @@ module.exports = [
   {
     name: 'new Function simple returns callable',
     src: `(new Function('return 42;'))();`,
-    expected: 42
+    expected: 42,
   },
   {
     src: `(new Function('return 42;')).length;`,
@@ -1685,22 +1685,22 @@ module.exports = [
   {
     name: 'new Function with args returns callable',
     src: `(new Function('a, b', 'c', 'return a + b * c;'))(2, 3, 10);`,
-    expected: 32
+    expected: 32,
   },
   {
     name: 'new Function with args .length',
     src: `(new Function('a, b', 'c', 'return a + b * c;')).length;`,
-    expected: 3
+    expected: 3,
   },
   {
     name: 'new Function with args .toString()',
     src: `String(new Function('a, b', 'c', 'return a + b * c;'))`,
-    expected: 'function(a, b,c) {return a + b * c;}'
+    expected: 'function(a, b,c) {return a + b * c;}',
   },
   {
     name: 'Function.prototype has no .prototype',
     src: `Function.prototype.hasOwnProperty('prototype');`,
-    expected: false
+    expected: false,
   },
   {
     name: 'Function.prototype.toString applied to non-fucntion throws',
@@ -1711,7 +1711,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Function.prototype.apply non-function throws',
@@ -1724,7 +1724,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Function.prototype.apply this',
@@ -1733,7 +1733,7 @@ module.exports = [
       function f() {return this;}
       f.apply(o, []) === o;
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Function.prototype.apply(..., undefined) or null',
@@ -1744,7 +1744,7 @@ module.exports = [
       f.apply(undefined, null);
       n;
     `,
-    expected: 0
+    expected: 0,
   },
   {
     name: 'Function.prototype.apply(..., non-object)',
@@ -1755,7 +1755,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Function.prototype.apply(..., sparse)',
@@ -1767,7 +1767,7 @@ module.exports = [
         return a + c;
       }).apply(undefined, [1, , 3]);
     `,
-    expected: 4
+    expected: 4,
   },
   {
     name: 'Function.prototype.apply(..., array-like)',
@@ -1776,7 +1776,7 @@ module.exports = [
         return a + b + c;
       }).apply(undefined, {0: 1, 1: 2, 2: 3, length: 3});
     `,
-    expected: 6
+    expected: 6,
   },
   {
     name: 'Function.prototype.apply(..., non-array-like)',
@@ -1785,7 +1785,7 @@ module.exports = [
         return a + b + c;
       }).apply(undefined, {0: 1, 1: 2, 2: 4});
     `,
-    expected: NaN  // Because undefined + undefined === NaN.
+    expected: NaN  // Because undefined + undefined === NaN.,
   },
   {
     name: 'Function.prototype.call non-function throws',
@@ -1798,7 +1798,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Function.prototype.call this',
@@ -1807,12 +1807,12 @@ module.exports = [
       function f() {return this;}
       f.call(o) === o;
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Function.prototype.call no args',
     src: `(function() {return arguments.length;}).call();`,
-    expected: 0
+    expected: 0,
   },
   {
     name: 'Function.prototype.call',
@@ -1824,7 +1824,7 @@ module.exports = [
         return a + c;
       }).call(undefined, 1, 2, 3);
     `,
-    expected: 4
+    expected: 4,
   },
   {
     name: 'Function.prototype.bind non-function throws',
@@ -1837,7 +1837,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'Function.prototype.bind this',
@@ -1846,12 +1846,12 @@ module.exports = [
       function f() {return this;}
       f.bind(o)() === o;
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Function.prototype.bind no args',
     src: `(function() {return arguments.length;}).bind()();`,
-    expected: 0
+    expected: 0,
   },
   {
     name: 'Function.prototype.bind',
@@ -1861,7 +1861,7 @@ module.exports = [
         return a + b + c + d;
       }).bind(undefined, 1).bind(undefined, 2)(3);
     `,
-    expected: 10
+    expected: 10,
   },
   {
     name: 'Function.prototype.bind call BF',
@@ -1872,7 +1872,7 @@ module.exports = [
       f();
       constructed;
     `,
-    expected: false
+    expected: false,
   },
   {
     name: 'Function.prototype.bind construct BF',
@@ -1883,7 +1883,7 @@ module.exports = [
       new f;
       constructed;
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Function.prototype.call.bind construct BF',
@@ -1897,7 +1897,7 @@ module.exports = [
         !invoked && e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   // N.B.: tests of semantics of class constructors are unavoidably ES6.
   {
@@ -1910,20 +1910,20 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   // N.B.: tests of semantics of class constructors are unavoidably ES6.
   {
     name: 'Function.prototype.bind class constructor',
     src: `String(new (WeakMap.bind()));`,
-    expected: '[object WeakMap]'
+    expected: '[object WeakMap]',
   },
   /////////////////////////////////////////////////////////////////////////////
   // Array and Array.prototype
   {
     name: 'new Array()',
     src: `var a = new Array(); Array.isArray(a) && a.length;`,
-    expected: 0
+    expected: 0,
   },
   {
     name: 'newArray(/* number */)',
@@ -1931,7 +1931,7 @@ module.exports = [
       var a = new Array(42);
       Array.isArray(a) && !(0 in a) && !(41 in a) && a.length;
     `,
-    expected: 42
+    expected: 42,
   },
   {
     name: 'new Array(/* non-number */)',
@@ -1939,7 +1939,7 @@ module.exports = [
       var a = new Array('foo');
       Array.isArray(a) && a.length === 1 && a[0];
     `,
-    expected: 'foo'
+    expected: 'foo',
   },
   {
     name: 'new Array(/* multiple args */)',
@@ -1947,7 +1947,7 @@ module.exports = [
       var a = new Array(1, 2, 3);
       Array.isArray(a) && a.length === 3 && String(a);
     `,
-    expected: '1,2,3'
+    expected: '1,2,3',
   },
   {
     src: `Array.isArray(Array.prototype);`,
@@ -1972,7 +1972,7 @@ module.exports = [
       var c = a.concat();
       a.length === 6 && c.length === 6 && c !== a && String(c);
     `,
-    expected: 'foo,bar,baz,,quux,quuux'
+    expected: 'foo,bar,baz,,quux,quuux',
   },
   {
     name: 'Array.prototype.concat(...)',
@@ -1981,7 +1981,7 @@ module.exports = [
       var c = [].concat(['foo', 'bar'], 'baz', undefined, o);
       c.length === 5 && '3' in c && c[3] === undefined && String(c);
     `,
-    expected: 'foo,bar,baz,,[object Object]'
+    expected: 'foo,bar,baz,,[object Object]',
   },
   {
     name: 'Array.prototype.concat.call(object, ...)',
@@ -1990,7 +1990,7 @@ module.exports = [
       var c = Array.prototype.concat.call(o, 'baz', [, 'quux', 'quuux']);
       c.length === 5 && String(c);
     `,
-    expected: '[object Object],baz,,quux,quuux'
+    expected: '[object Object],baz,,quux,quuux',
   },
   {
     src: `[1, 2, 3, 2, 1].includes(2);`,
@@ -2003,12 +2003,12 @@ module.exports = [
   {
     name: 'Array.prototype.includes fromIndex',
     src: `[1, 2, 3, 2, 1].includes(2, 2);`,
-    expected: true
+    expected: true,
   },
   {
     name: 'Array.prototype.includes negative fromIndex',
     src: `[1, 2, 3, 2, 1].includes(1, -3);`,
-    expected: true
+    expected: true,
   },
   {
     src: `['x', NaN, 'y'].includes(NaN);`,
@@ -2020,32 +2020,32 @@ module.exports = [
       var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
       Array.prototype.includes.call(o, 2);
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Array.prototype.indexOf',
     src: `[1, 2, 3, 2, 1].indexOf(2);`,
-    expected: 1
+    expected: 1,
   },
   {
     name: 'Array.prototype.indexOf not found',
     src: `[1, 2, 3, 2, 1].indexOf(4);`,
-    expected: -1
+    expected: -1,
   },
   {
     name: 'Array.prototype.indexOf fromIndex',
     src: `[1, 2, 3, 2, 1].indexOf(2, 2);`,
-    expected: 3
+    expected: 3,
   },
   {
     name: 'Array.prototype.indexOf negative fromIndex',
     src: `[1, 2, 3, 2, 1].indexOf(1, -3);`,
-    expected: 4
+    expected: 4,
   },
   {
     name: 'Array.prototype.indexOf NaN',
     src: `['x', NaN, 'y'].indexOf(NaN);`,
-    expected: -1
+    expected: -1,
   },
   {
     name: 'Array.prototype.indexOf.call(array-like, ...)',
@@ -2053,12 +2053,12 @@ module.exports = [
       var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
       Array.prototype.indexOf.call(o, 2);
     `,
-    expected: 1
+    expected: 1,
   },
   {
     name: 'Array.prototype.join',
     src: `[1, 2, 3].join('-');`,
-    expected: '1-2-3'
+    expected: '1-2-3',
   },
   {
     name: 'Array.prototype.join cycle detection',
@@ -2068,27 +2068,27 @@ module.exports = [
       a.join('-');
       "Didn't crash!";
     `,
-    expected: 'Didn\'t crash!'
+    expected: 'Didn\'t crash!',
   },
   {
     name: 'Array.prototype.lastIndexOf',
     src: `[1, 2, 3, 2, 1].lastIndexOf(2);`,
-    expected: 3
+    expected: 3,
   },
   {
     name: 'Array.prototype.lastIndexOf not found',
     src: `[1, 2, 3, 2, 1].lastIndexOf(4);`,
-    expected: -1
+    expected: -1,
   },
   {
     name: 'Array.prototype.lastIndexOf(..., +)',
     src: `[1, 2, 3, 2, 1].lastIndexOf(2, 2);`,
-    expected: 1
+    expected: 1,
   },
   {
     name: 'Array.prototype.lastIndexOf(..., -)',
     src: `[1, 2, 3, 2, 1].lastIndexOf(1, -3);`,
-    expected: 0
+    expected: 0,
   },
   {
     name: 'Array.prototype.lastIndexOf.call(array-like, ...)',
@@ -2096,7 +2096,7 @@ module.exports = [
       var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
       Array.prototype.lastIndexOf.call(o, 2);
     `,
-    expected: 3
+    expected: 3,
   },
   {
     name: 'Array.prototype.pop',
@@ -2105,7 +2105,7 @@ module.exports = [
       var r = a.pop();
       a.length === 2 && r;
     `,
-    expected: 'baz'
+    expected: 'baz',
   },
   {
     name: 'Array.prototype.pop empty array',
@@ -2114,7 +2114,7 @@ module.exports = [
       var r = a.pop();
       a.length === 0 && r;
     `,
-    expected: undefined
+    expected: undefined,
   },
   {
     name: 'Array.prototype.pop.apply(array-like)',
@@ -2123,7 +2123,7 @@ module.exports = [
       var r = Array.prototype.pop.apply(o);
       o.length === 2 && r;
     `,
-    expected: 'baz'
+    expected: 'baz',
   },
   {
     name: 'Array.prototype.pop.apply(empty array-like)',
@@ -2132,7 +2132,7 @@ module.exports = [
       var r = Array.prototype.pop.apply(o);
       o.length === 0 && r;
     `,
-    expected: undefined
+    expected: undefined,
   },
   {
     name: 'Array.prototype.pop.apply(huge array-like)',
@@ -2143,7 +2143,7 @@ module.exports = [
       var r = Array.prototype.pop.apply(o);
       o.length === 5000000000000001 && o[5000000000000000] === 'foo' && r;
     `,
-    expected: 'quux'
+    expected: 'quux',
   },
   {
     name: 'Array.prototype.push',
@@ -2152,7 +2152,7 @@ module.exports = [
       a.push('foo') === 1 && a.push('bar') === 2 &&
           a.length === 2 && a[0] === 'foo' && a[1] === 'bar';
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Array.prototype.push.call(array-like, ...)',
@@ -2162,7 +2162,7 @@ module.exports = [
           Array.prototype.push.call(o, 'bar') === 2 &&
           o.length === 2 && o[0] === 'foo' && o[1] === 'bar';
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Array.prototype.push.call(huge array-like, ...)',
@@ -2174,7 +2174,7 @@ module.exports = [
           o[5000000000000000] === 'foo' && o[5000000000000001] === 'bar' &&
           o.length === 5000000000000002
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Array.prototype.reverse odd-length',
@@ -2182,7 +2182,7 @@ module.exports = [
       var a = [1, 2, 3];
       a.reverse() === a && a.length === 3 && String(a);
     `,
-    expected: '3,2,1'
+    expected: '3,2,1',
   },
   {
     name: 'Array.prototype.reverse even-length',
@@ -2190,7 +2190,7 @@ module.exports = [
       var a = [1, 2, , 4];
       a.reverse() === a && a.length === 4 && String(a);
     `,
-    expected: '4,,2,1'
+    expected: '4,,2,1',
   },
   {
     name: 'Array.prototype.reverse empty',
@@ -2198,7 +2198,7 @@ module.exports = [
       var a = [];
       a.reverse() === a && a.length;
     `,
-    expected: 0
+    expected: 0,
   },
   {
     name: 'Array.prototype.reverse.call(odd-length array-like)',
@@ -2207,7 +2207,7 @@ module.exports = [
       Array.prototype.reverse.call(o) === o && o.length === 3 &&
           Array.prototype.slice.apply(o).toString();
     `,
-    expected: '3,2,1'
+    expected: '3,2,1',
   },
   {
     name: 'Array.prototype.reverse.call(even-length array-like)',
@@ -2216,7 +2216,7 @@ module.exports = [
       Array.prototype.reverse.call(o) === o && o.length === 4 &&
           Array.prototype.slice.apply(o).toString();
     `,
-    expected: '4,,2,1'
+    expected: '4,,2,1',
   },
   {
     name: 'Array.prototype.reverse.call(empty array-like)',
@@ -2224,7 +2224,7 @@ module.exports = [
       var o = {length: 0};
       Array.prototype.reverse.call(o) === o && o.length;
     `,
-    expected: 0
+    expected: 0,
   },
   {
     name: 'Array.prototype.shift',
@@ -2233,7 +2233,7 @@ module.exports = [
       var r = a.shift();
       a.length === 2 && a[0] === 'bar' && a[1] === 'baz' && r;
     `,
-    expected: 'foo'
+    expected: 'foo',
   },
   {
     name: 'Array.prototype.shift empty array',
@@ -2242,7 +2242,7 @@ module.exports = [
       var r = a.shift();
       a.length === 0 && r;
     `,
-    expected: undefined
+    expected: undefined,
   },
   {
     name: 'Array.prototype.shift.apply(array-like)',
@@ -2251,7 +2251,7 @@ module.exports = [
       var r = Array.prototype.shift.apply(o);
       o.length === 2 && o[0] === 'bar' && o[1] === 'baz' && r;
     `,
-    expected: 'foo'
+    expected: 'foo',
   },
   {
     name: 'Array.prototype.shift.apply(empty array-like)',
@@ -2260,7 +2260,7 @@ module.exports = [
       var r = Array.prototype.shift.apply(o);
       o.length === 0 && r;
     `,
-    expected: undefined
+    expected: undefined,
   },
   {
     name: 'Array.prototype.shift.apply(huge array-like)',
@@ -2281,7 +2281,7 @@ module.exports = [
       var s = a.slice();
       a.length === 6 && s.length === 6 && String(s);
     `,
-    expected: 'foo,bar,baz,,quux,quuux'
+    expected: 'foo,bar,baz,,quux,quuux',
   },
   {
     name: 'Array.prototype.slice(-)',
@@ -2290,7 +2290,7 @@ module.exports = [
       var s = a.slice(-2);
       a.length === 6 && s.length === 2 && String(s);
     `,
-    expected: 'quux,quuux'
+    expected: 'quux,quuux',
   },
   {
     name: 'Array.prototype.slice(+, +)',
@@ -2299,7 +2299,7 @@ module.exports = [
       var s = a.slice(1, 4);
       a.length === 6 && s.length === 3 && !('2' in s) && String(s);
     `,
-    expected: 'bar,baz,'
+    expected: 'bar,baz,',
   },
   {
     name: 'Array.prototype.slice(+, -)',
@@ -2308,7 +2308,7 @@ module.exports = [
       var s = a.slice(1, -2);
       a.length === 6 && s.length === 3 && !('2' in s) && String(s);
     `,
-    expected: 'bar,baz,'
+    expected: 'bar,baz,',
   },
   {
     name: 'Array.prototype.slice.call(array-like, -, +)',
@@ -2320,7 +2320,7 @@ module.exports = [
       !Array.isArray(o) && o.length === 6 &&
           Array.isArray(s) && s.length === 3 && !('2' in s) && String(s);
     `,
-    expected: 'bar,baz,'
+    expected: 'bar,baz,',
   },
   {
     name: 'Array.prototype.slice.call(huge array-like, -, -)',
@@ -2334,12 +2334,12 @@ module.exports = [
       !Array.isArray(o) && o.length === 5000000000000006 &&
           Array.isArray(s) && s.length === 3 && !('2' in s) && String(s);
     `,
-    expected: 'bar,baz,'
+    expected: 'bar,baz,',
   },
   {
     name: 'Array.prototype.sort()',
     src: `[5, 2, 3, 1, 4].sort().join();  // Sorts ASCIIbetically.`,
-    expected: '1,2,3,4,5'
+    expected: '1,2,3,4,5',
   },
   {
     name: 'Array.prototype.sort() compaction',
@@ -2347,7 +2347,7 @@ module.exports = [
       ['z', undefined, 10, , 'aa', null, 'a', 5, NaN, , 1].sort()
           .map(String).join();
     `,
-    expected: '1,10,5,NaN,a,aa,null,z,undefined,,'
+    expected: '1,10,5,NaN,a,aa,null,z,undefined,,',
   },
   {
     name: 'Array.prototype.sort(/* comparefn */)',
@@ -2355,7 +2355,7 @@ module.exports = [
       [99, 9, 10, 11, 1, 0, 5]
           .sort(function(a, b) {return a - b;}).join();
     `,
-    expected: '0,1,5,9,10,11,99'
+    expected: '0,1,5,9,10,11,99',
   },
   {
     name: 'Array.prototype.sort(/* comparefn */) compaction',
@@ -2373,7 +2373,7 @@ module.exports = [
             return 0;
           }).map(String).join();
     `,
-    expected: 'z,null,aa,a,NaN,5,10,1,undefined,,'
+    expected: 'z,null,aa,a,NaN,5,10,1,undefined,,',
   },
   {
     name: 'Array.prototype.splice()',
@@ -2382,7 +2382,7 @@ module.exports = [
       var s = a.splice();
       a.length === 6 && s.length === 0 && String(a) + ':' + String(s);
     `,
-    expected: 'foo,bar,baz,,quux,quuux:'
+    expected: 'foo,bar,baz,,quux,quuux:',
   },
   {
     name: 'Array.prototype.splice(-)',
@@ -2391,7 +2391,7 @@ module.exports = [
       var s = a.splice(-2);
       a.length === 4 && s.length === 2 && String(a) + ':' + String(s);
     `,
-    expected: 'foo,bar,baz,:quux,quuux'
+    expected: 'foo,bar,baz,:quux,quuux',
   },
   {
     name: 'Array.prototype.splice(+, +, ...)',
@@ -2400,7 +2400,7 @@ module.exports = [
       var s = a.splice(1, 3, 'bletch');
       a.length === 4 && s.length === 3 && String(a) + ':' + String(s);
     `,
-    expected: 'foo,bletch,quux,quuux:bar,baz,'
+    expected: 'foo,bletch,quux,quuux:bar,baz,',
   },
   {
     name: 'Array.prototype.splice.call(array-like, 0, large, ...)',
@@ -2413,7 +2413,7 @@ module.exports = [
       o[0] === 'bletch' &&
       Array.isArray(s) && s.length === 6 && !('3' in s) && String(s);
     `,
-    expected: 'foo,bar,baz,,quux,quuux'
+    expected: 'foo,bar,baz,,quux,quuux',
   },
   {
     name: 'Array.prototype.splice.call(huge array-like, -, -, many...)',
@@ -2429,7 +2429,7 @@ module.exports = [
           o[5000000000000006] === 'quux' && o[5000000000000007] === 'quuux' &&
           Array.isArray(s) && s.length === 0;
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Array.prototype.toString cycle detection',
@@ -2439,17 +2439,17 @@ module.exports = [
       a.toString();
       "Didn't crash!";
     `,
-    expected: 'Didn\'t crash!'
+    expected: 'Didn\'t crash!',
   },
   {
     name: 'Array.prototype.toString.call(obj-w/join)',
     src: `Array.prototype.toString.apply({join: function() {return 'OK';}});`,
-    expected: 'OK'
+    expected: 'OK',
   },
   {
     name: 'Array.prototype.toString.call(array-like)',
     src: `Array.prototype.toString.apply({0: 'foo', 1: 'bar', length: 2});`,
-    expected: '[object Object]'
+    expected: '[object Object]',
   },
   {
     name: 'Array.prototype.unshift',
@@ -2458,7 +2458,7 @@ module.exports = [
       a.unshift('foo') === 1 && a.unshift('bar') === 2 &&
           a.length === 2 && a[0] === 'bar' && a[1] === 'foo';
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Array.prototype.unshift.call(array-like, ...)',
@@ -2468,7 +2468,7 @@ module.exports = [
           Array.prototype.unshift.call(o, 'bar') === 2 &&
           o.length === 2 && o[0] === 'bar' && o[1] === 'foo';
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Array.prototype.unshift.call(huge array-like, ...)',
@@ -2510,7 +2510,7 @@ module.exports = [
       }
       (ok === tests.length) ? 'pass' : 'fail';
     `,
-    expected: 'pass'
+    expected: 'pass',
   },
   {
     src: `Boolean.prototype.toString();`,
@@ -2533,7 +2533,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     src: `Boolean.prototype.valueOf();`,
@@ -2556,7 +2556,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   /////////////////////////////////////////////////////////////////////////////
   // Number and Number.prototype
@@ -2585,7 +2585,7 @@ module.exports = [
       }
       (ok === tests.length) ? 'pass' : 'fail';
     `,
-    expected: 'pass'
+    expected: 'pass',
   },
   {
     name: 'Number.MAX_SAFE_INTEGER',
@@ -2594,7 +2594,7 @@ module.exports = [
           Number.isSafeInteger(Number.MAX_SAFE_INTEGER) &&
           !Number.isSafeInteger(Number.MAX_SAFE_INTEGER + 1);
     `,
-    expected: true
+    expected: true,
   },
   {
     src: `Number.prototype.toString();`,
@@ -2613,7 +2613,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     src: `Number.prototype.valueOf();`,
@@ -2632,7 +2632,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   /////////////////////////////////////////////////////////////////////////////
   // String and String.prototype
@@ -2661,7 +2661,7 @@ module.exports = [
       }
       (ok === tests.length) ? 'pass' : 'fail';
     `,
-    expected: 'pass'
+    expected: 'pass',
   },
   {
     name: 'String calls valueOf',
@@ -2670,7 +2670,7 @@ module.exports = [
       o.valueOf = function() {return 'OK';};
       String(o);
     `,
-    expected: 'OK'
+    expected: 'OK',
   },
   {
     name: 'String calling valueOf returns string',
@@ -2679,7 +2679,7 @@ module.exports = [
       o.valueOf = function() {return 42;};
       String(o);
     `,
-    expected: '42'
+    expected: '42',
   },
   {
     name: 'String calling valueOf throws',
@@ -2692,7 +2692,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'String calls toString',
@@ -2702,7 +2702,7 @@ module.exports = [
       o.toString = function() {return 'OK';};
       String(o);
     `,
-    expected: 'OK'
+    expected: 'OK',
   },
   {
     name: 'String calling toString returns string',
@@ -2711,7 +2711,7 @@ module.exports = [
       o.valueOf = function() {return 42;};
       String(o);
     `,
-    expected: '42'
+    expected: '42',
   },
   {
     name: 'String calling toString throws',
@@ -2725,7 +2725,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     src: `String.prototype.length;`,
@@ -2734,12 +2734,12 @@ module.exports = [
   {
     name: 'String.prototype.replace(string, string)',
     src: `'xxxx'.replace('xx', 'y');`,
-    expected: 'yxx'
+    expected: 'yxx',
   },
   {
     name: 'String.prototype.replace(regexp, string)',
     src: `'xxxx'.replace(/(X)\\1/ig, 'y');`,
-    expected: 'yy'
+    expected: 'yy',
   },
   {
     name: 'String.prototype.replace(string, function)',
@@ -2748,7 +2748,7 @@ module.exports = [
            return '[' + Array.prototype.join.apply(arguments) + ']';
       });
     `,
-    expected: '[xx,0,xxxx]xx'
+    expected: '[xx,0,xxxx]xx',
   },
   {
     name: 'String.prototype.replace(regexp, function)',
@@ -2757,27 +2757,27 @@ module.exports = [
            return '[' + Array.prototype.join.apply(arguments) + ']';
       });
     `,
-    expected: '[xx,x,0,xxxx][xx,x,2,xxxx]'
+    expected: '[xx,x,0,xxxx][xx,x,2,xxxx]',
   },
   {
     name: 'String.prototype.search(string) not found',
     src: `'hello'.search('H')`,
-    expected: -1
+    expected: -1,
   },
   {
     name: 'String.prototype.search(string) found',
     src: `'hello'.search('ll')`,
-    expected: 2
+    expected: 2,
   },
   {
     name: 'String.prototype.search(regexp) not found',
     src: `'hello'.search(/H/)`,
-    expected: -1
+    expected: -1,
   },
   {
     name: 'String.prototype.search(regexp) found',
     src: `'hello'.search(/(.)\\1/)`,
-    expected: 2
+    expected: 2,
   },
   {
     src: `String.prototype.toString();`,
@@ -2786,7 +2786,7 @@ module.exports = [
   {
     name: 'String.prototype.toString.call primitive',
     src: `String.prototype.toString.call('a string');`,
-    expected: 'a string'
+    expected: 'a string',
   },
   {
     name: 'String.prototype.toString.call non-String object',
@@ -2797,7 +2797,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     src: `String.prototype.valueOf();`,
@@ -2806,7 +2806,7 @@ module.exports = [
   {
     name: 'String.prototype.valueOf.call primitive',
     src: `String.prototype.valueOf.call('a string');`,
-    expected: 'a string'
+    expected: 'a string',
   },
   {
     name: 'String.prototype.valueOf.call non-String object',
@@ -2817,7 +2817,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   /////////////////////////////////////////////////////////////////////////////
   // RegExp
@@ -2830,7 +2830,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   /////////////////////////////////////////////////////////////////////////////
   // Error and Error.prototype (and all the other native error types too)
@@ -2842,7 +2842,7 @@ module.exports = [
       var lines = e.stack.split('\\n');
       lines[0].trim();
     `,
-    expected: 'at "new Error;" 1:1'
+    expected: 'at "new Error;" 1:1',
   },
   {
     name: 'thrown Error has .stack',
@@ -2854,7 +2854,7 @@ module.exports = [
       }
       lines[0].trim();
     `,
-    expected: 'at buggy 1:19'
+    expected: 'at buggy 1:19',
   },
   {
     name: 'Error .stack correctly reports anonymous function',
@@ -2864,7 +2864,7 @@ module.exports = [
       var lines = e.stack.split('\\n');
       lines[0].trim();
     `,
-    expected: 'at anonymous function 1:20'
+    expected: 'at anonymous function 1:20',
   },
   // Bug #241.
   {
@@ -2883,7 +2883,7 @@ module.exports = [
       }
       lines[0].trim();
     `,
-    expected: 'at foo 4:20'
+    expected: 'at foo 4:20',
   },
   {
     name: 'Error .stack correctly blames Identifier',
@@ -2898,7 +2898,7 @@ module.exports = [
       }
       lines[0].trim();
     `,
-    expected: 'at foo 2:16'
+    expected: 'at foo 2:16',
   },
   /////////////////////////////////////////////////////////////////////////////
   // JSON
@@ -2910,7 +2910,7 @@ module.exports = [
           object: {obj: {}, arr: []}, array: [{}, []] });
     `,
     expected: '{"string":"foo","number":42,"true":true,"false":false,' +
-        '"null":null,"object":{"obj":{},"arr":[]},"array":[{},[]]}'
+        '"null":null,"object":{"obj":{},"arr":[]},"array":[{},[]]}',
   },
   {
     src: `JSON.stringify(function(){});`,
@@ -2932,7 +2932,7 @@ module.exports = [
           object: {obj: {}, arr: []}, array: [{}, []] },
           ['string', 'number']);
     `,
-    expected: '{"string":"foo","number":42}'
+    expected: '{"string":"foo","number":42}',
   },
   {
     name: 'JSON.stringify pretty number',
@@ -2942,7 +2942,7 @@ module.exports = [
           object: {obj: {}, arr: []}, array: [{}, []] },
           ['string', 'number'], 2);
     `,
-    expected: '{\n  "string": "foo",\n  "number": 42\n}'
+    expected: '{\n  "string": "foo",\n  "number": 42\n}',
   },
   {
     name: 'JSON.stringify pretty string',
@@ -2952,7 +2952,7 @@ module.exports = [
           object: {obj: {}, arr: []}, array: [{}, []] },
           ['string', 'number'], '--');
     `,
-    expected: '{\n--"string": "foo",\n--"number": 42\n}'
+    expected: '{\n--"string": "foo",\n--"number": 42\n}',
   },
   {
     name: 'JSON.stringify nonenumerable',
@@ -2961,12 +2961,12 @@ module.exports = [
       Object.defineProperty(obj, 'ne', {enumerable: false});
       JSON.stringify(obj);
     `,
-    expected: '{"e":"enumerable"}'
+    expected: '{"e":"enumerable"}',
   },
   {
     name: 'JSON.stringify inherited',
     src: `JSON.stringify(Object.create({foo: 'bar'}));`,
-    expected: '{}'
+    expected: '{}',
   },
   {
     name: 'JSON.stringify circular',
@@ -2979,7 +2979,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   /////////////////////////////////////////////////////////////////////////////
   // Other built-in functions
@@ -2992,7 +2992,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'URIError'
+    expected: 'URIError',
   },
   /////////////////////////////////////////////////////////////////////////////
   // WeakMap
@@ -3013,7 +3013,7 @@ module.exports = [
       !w.has(o) || fails++;
       fails;
     `,
-    expected: 0
+    expected: 0,
   },
   {
     name: 'WeakMap.prototype methods reject non-WeakMap this',
@@ -3042,7 +3042,7 @@ module.exports = [
       }
       fails;
     `,
-    expected: 0
+    expected: 0,
   },
   {
     name: 'WeakMap',
@@ -3061,7 +3061,7 @@ module.exports = [
       !w.has(o) || fails++;
       fails;
     `,
-    expected: 0
+    expected: 0,
   },
   /////////////////////////////////////////////////////////////////////////////
   // Thread and Thread.prototype:
@@ -3086,7 +3086,7 @@ module.exports = [
   {
     name: 'Thread.callers()[0].line & .col',
     src: 'var frame = Thread.callers()[0]; frame.line + "," + frame.col;',
-    expected: '1,13'
+    expected: '1,13',
   },
   {
     name: 'Thread.callers()[/* last */].program',
@@ -3094,7 +3094,7 @@ module.exports = [
       var callers = Thread.callers();
       typeof callers[callers.length - 1].program;
     `,
-    expected: 'string'
+    expected: 'string',
   },
   {
     name: 'Thread.callers()[0].callerPerms',
@@ -3107,7 +3107,7 @@ module.exports = [
       setPerms(user);
       f();
     `,
-    expected: 'user'
+    expected: 'user',
   },
   // Time limit tests.  Actual enforcement is tested in
   // interpreter_tests.js; this is just checking behaviour of get/set
@@ -3115,7 +3115,7 @@ module.exports = [
   {
     name: 'Thread.prototype.getTimeLimit() initially 0',
     src: `Thread.current().getTimeLimit();`,
-    expected: 0
+    expected: 0,
   },
   {
     name: 'Thread.prototype.setTimeLimit()',
@@ -3123,7 +3123,7 @@ module.exports = [
       Thread.current().setTimeLimit(1000);
       Thread.current().getTimeLimit();
     `,
-    expected: 1000
+    expected: 1000,
   },
   {
     name: 'Thread.prototype.setTimeLimit(...)',
@@ -3131,7 +3131,7 @@ module.exports = [
       Thread.current().setTimeLimit(1000);
       Thread.current().getTimeLimit();
     `,
-    expected: 1000
+    expected: 1000,
   },
   // Check invalid time limits are rejected.
   {
@@ -3149,14 +3149,14 @@ module.exports = [
       }
       (failures.length === 0) ? 'OK' : String(failures);
     `,
-    expected: 'OK'
+    expected: 'OK',
   },
   /////////////////////////////////////////////////////////////////////////////
   // Permissions system:
   {
     name: 'perms returns root',
     src: `perms() === CC.root;`,
-    expected: true
+    expected: true,
   },
   {
     name: 'setPerms',
@@ -3174,7 +3174,7 @@ module.exports = [
       r += perms().name;
       r;
     `,
-    expected: 'RootBobRoot'
+    expected: 'RootBobRoot',
   },
   {
     name: 'getOwnerOf',
@@ -3187,7 +3187,7 @@ module.exports = [
       Object.getOwnerOf(roots) === CC.root &&
       Object.getOwnerOf(bobs) === bob
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'setOwnerOf',
@@ -3196,14 +3196,14 @@ module.exports = [
       var obj = {};
       Object.setOwnerOf(obj, bob) === obj && Object.getOwnerOf(obj) === bob;
     `,
-    expected: true
+    expected: true,
   },
   /////////////////////////////////////////////////////////////////////////////
   // Other tests:
   {
     name: 'new hack',
     src: `(new 'Array.prototype.push') === Array.prototype.push`,
-    expected: true
+    expected: true,
   },
   {
     name: 'new hack with unkown builtin',
@@ -3214,7 +3214,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'ReferenceError'
+    expected: 'ReferenceError',
   },
   {
     name: 'new hack with other than string literal',
@@ -3226,7 +3226,7 @@ module.exports = [
         e.name;
       }
     `,
-    expected: 'TypeError'
+    expected: 'TypeError',
   },
   {
     name: 'ES6 causes syntax errors',
@@ -3256,7 +3256,7 @@ module.exports = [
       }
       failed.length ? failed.join('\\n') : 'OK';
     `,
-    expected: 'OK'
+    expected: 'OK',
   },
   {
     name: 'Strict mode syntax errors',
@@ -3288,7 +3288,7 @@ module.exports = [
       }
       failed.length ? failed.join('\\n') : 'OK';
     `,
-    expected: 'OK'
+    expected: 'OK',
   },
   {
     name: 'Stack overflow errors',
@@ -3300,7 +3300,7 @@ module.exports = [
       }
     `,
     options: {stackLimit: 100},
-    expected: 'RangeError'
+    expected: 'RangeError',
   },
   {
     name: 'Minimum stack depth limit',
@@ -3316,6 +3316,6 @@ module.exports = [
       limit > 100 ? 'OK' : limit;
     `,
     options: {stackLimit: 1000},
-    expected: 'OK'
+    expected: 'OK',
   },
 ];

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -54,22 +54,22 @@ module.exports = [
   {
     name: 'if(true)',
     src: `
-    if (true) {
-      'then';
-    } else {
-      'else';
-    }
+      if (true) {
+        'then';
+      } else {
+        'else';
+      }
     `,
     expected: 'then'
   },
   {
     name: 'if(false)',
     src: `
-    if (false) {
-      'then';
-    } else {
-      'else';
-    }
+      if (false) {
+        'then';
+      } else {
+        'else';
+      }
     `,
     expected: 'else'
   },
@@ -91,11 +91,11 @@ module.exports = [
   {
     name: 'setPropertyOnPrimitive',
     src: `
-    try {
-      'foo'.bar = 42;
-    } catch (e) {
-      e.name;
-    }
+      try {
+        'foo'.bar = 42;
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -129,9 +129,9 @@ module.exports = [
   {
     name: 'assignmentSetsAnonFuncName',
     src: `
-    var myAssignedFunc;
-    myAssignedFunc = function() {};
-    myAssignedFunc.name;
+      var myAssignedFunc;
+      myAssignedFunc = function() {};
+      myAssignedFunc.name;
     `,
     expected: 'myAssignedFunc'
   },
@@ -173,39 +173,39 @@ module.exports = [
   {
     name: 'multipleReturn',
     src: `
-    var f = function() {
-      try {
-        return true;
-      } finally {
-        return false;
+      var f = function() {
+        try {
+          return true;
+        } finally {
+          return false;
+        }
       }
-    }
-    f();
+      f();
     `,
     expected: false
   },
   {
     name: 'throwCatch',
     src: `
-    var f = function() {
-      throw 26;
-    }
-    try {
-      f();
-    } catch (e) {
-      e * 2;
-    }
+      var f = function() {
+        throw 26;
+      }
+      try {
+        f();
+      } catch (e) {
+        e * 2;
+      }
     `,
     expected: 52
   },
   {
     name: 'throwCatchFalsey',
     src: `
-    try {
-      throw null;
-    } catch (e) {
-      'caught ' + String(e);
-    }
+      try {
+        throw null;
+      } catch (e) {
+        'caught ' + String(e);
+      }
     `,
     expected: 'caught null'
   },
@@ -239,9 +239,9 @@ module.exports = [
   {
     name: 'sequenceExpression',
     src: `
-    var x, y, z;
-    x = (y = 60, z = 5, 0.5);
-    x + y + z;
+      var x, y, z;
+      x = (y = 60, z = 5, 0.5);
+      x + y + z;
     `,
     expected: 65.5
   },
@@ -253,40 +253,40 @@ module.exports = [
   {
     name: 'whileLoop',
     src: `
-    var a = 0;
-    while (a < 55) a++;
-    a;
+      var a = 0;
+      while (a < 55) a++;
+      a;
     `,
     expected: 55
   },
   {
     name: 'while(false)',
     src: `
-    var a = 56;
-    while (false) a++;
-    a;
+      var a = 56;
+      while (false) a++;
+      a;
     `,
     expected: 56
   },
   {
     name: 'do ... while(false)',
     src: `
-    var a = 56;
-    do a++; while (false);
-    a;
+      var a = 56;
+      do a++; while (false);
+      a;
     `,
     expected: 57
   },
   {
     name: 'do ... break ... while',
     src: `
-    var a = 57;
-    do {
-      a++;
-      break;
-      a++;
-    } while (false);
-    a;
+      var a = 57;
+      do {
+        a++;
+        break;
+        a++;
+      } while (false);
+      a;
     `,
     expected: 58
   },
@@ -297,63 +297,63 @@ module.exports = [
   {
     name: 'try ... break ... finally',
     src: `
-    var a = 6;
-    foo: {
-      try {
-        a *= 10;
-        break foo;
-      } finally {
-        a--;
+      var a = 6;
+      foo: {
+        try {
+          a *= 10;
+          break foo;
+        } finally {
+          a--;
+        }
       }
-    }
-    a;
+      a;
     `,
     expected: 59
   },
   {
     name: 'do ... while with try ... continue ... finally ...',
     src: `
-    var a = 59;
-    do {
-      try {
-        continue;
-      } finally {
-        a++;
-      }
-    } while (false);
-    a;
+      var a = 59;
+      do {
+        try {
+          continue;
+        } finally {
+          a++;
+        }
+      } while (false);
+      a;
     `,
     expected: 60
   },
   {
     name: 'while with try ... break ... finally continue',
     src: `
-    var a = 0;
-    while (a++ < 60) {
-      try {
-        break;
-      } finally {
-        continue;
+      var a = 0;
+      while (a++ < 60) {
+        try {
+          break;
+        } finally {
+          continue;
+        }
       }
-    }
-    a;
+      a;
     `,
     expected: 61
   },
   {
     name: 'while with try ... return ... finally continue',
     src: `
-    (function() {
-      var i = 0;
-      while (i++ < 61) {
-        try {
-          return 42;
-        } finally {
-          continue;
+      (function() {
+        var i = 0;
+        while (i++ < 61) {
+          try {
+            return 42;
+          } finally {
+            continue;
+          }
         }
-      }
-      return i;
-    })();
+        return i;
+      })();
     `,
     expected: 62
   },
@@ -386,107 +386,107 @@ module.exports = [
   {
     name: 'for',
     src: `
-    var t = 0;
-    for (var i = 0; i < 12; i++) {
-      t += i;
-    }
-    t;
+      var t = 0;
+      for (var i = 0; i < 12; i++) {
+        t += i;
+      }
+      t;
     `,
     expected: 66
   },
   {
     name: 'forIn',
     src: `
-    var x = 0, a = {a: 60, b:3, c:4};
-    for (var i in a) {x += a[i];}
-    x;
+      var x = 0, a = {a: 60, b:3, c:4};
+      for (var i in a) {x += a[i];}
+      x;
     `,
     expected: 67
   },
   {
     name: 'forInMemberExp',
     src: `
-    var x = 1, o = {foo: 'bar'}, a = {a:2, b:2, c:17};
-    for (o.foo in a) {x *= a[o.foo];}
-    x;
+      var x = 1, o = {foo: 'bar'}, a = {a:2, b:2, c:17};
+      for (o.foo in a) {x *= a[o.foo];}
+      x;
     `,
     expected: 68
   },
   {
     name: 'forInMembFunc',
     src: `
-    var x = 0, o = {};
-    var f = function() {x += 20; return o;};
-    var a = {a:2, b:3, c:4};
-    for (f().foo in a) {x += a[o.foo];}
-    x;
+      var x = 0, o = {};
+      var f = function() {x += 20; return o;};
+      var a = {a:2, b:3, c:4};
+      for (f().foo in a) {x += a[o.foo];}
+      x;
     `,
     expected: 69
   },
   {
     name: 'forInNullUndefined',
     src: `
-    var x = 0, o = {};
-    var f = function() {x++; return o;};
-    for (f().foo in null) {x++;}
-    for (f().foo in undefined) {x++;}
-    x;
+      var x = 0, o = {};
+      var f = function() {x++; return o;};
+      for (f().foo in null) {x++;}
+      for (f().foo in undefined) {x++;}
+      x;
     `,
     expected: 0
   },
   {
     name: 'switchDefaultFirst',
     src: `
-    switch ('not found') {
-      default:
-        'OK';
-        break;
-      case 'decoy':
-        'fail';
-    };
+      switch ('not found') {
+        default:
+          'OK';
+          break;
+        case 'decoy':
+          'fail';
+      };
     `,
     expected: 'OK'
   },
   {
     name: 'switchDefaultOnly',
     src: `
-    switch ('not found') {
-      default:
-        'OK';
-    };
+      switch ('not found') {
+        default:
+          'OK';
+      };
     `,
     expected: 'OK'
   },
   {
     name: 'switchEmptyToEnd',
     src: `
-    'ok';
-    switch ('foo') {
-      default:
-        'fail';
-      case 'foo':
-      case 'bar':
-    };
+      'ok';
+      switch ('foo') {
+        default:
+          'fail';
+        case 'foo':
+        case 'bar':
+      };
     `,
     expected: 'ok'
   },
   {
     name: 'thisInMethod',
     src: `
-    var o = {
-      f: function() {return this.foo;},
-      foo: 70
-    };
-    o.f();
+      var o = {
+        f: function() {return this.foo;},
+        foo: 70
+      };
+      o.f();
     `,
     expected: 70
   },
   {
     name: 'thisInFormerMethod',
     src: `
-    var o = {f: function() {return this;}};
-    var g = o.f;
-    g();
+      var o = {f: function() {return this;}};
+      var g = o.f;
+      g();
     `,
     expected: undefined
   },
@@ -506,126 +506,126 @@ module.exports = [
   {
     name: 'arrayElidedNotDefinedNotUndefined',
     src: `
-    var a = [,undefined,null,0,false];
-    !(0 in a) && (1 in a) && (2 in a) && (3 in a) && (4 in a);
+      var a = [,undefined,null,0,false];
+      !(0 in a) && (1 in a) && (2 in a) && (3 in a) && (4 in a);
     `,
     expected: true
   },
   {
     name: 'arrayLengthPropertyDescriptor',
     src: `
-    var a = [1, 2, 3];
-    var pd = Object.getOwnPropertyDescriptor(a, 'length');
-    (pd.value === 3) && pd.writable && !pd.enumerable && !pd.configurable;
+      var a = [1, 2, 3];
+      var pd = Object.getOwnPropertyDescriptor(a, 'length');
+      (pd.value === 3) && pd.writable && !pd.enumerable && !pd.configurable;
     `,
     expected: true
   },
   {
     name: 'arrayLength',
     src: `
-    try {
-      var a;
-      function checkLen(exp, desc) {
-        if (a.length !== exp) {
-          var msg = 'a.length === ' + a.length + ' (expected: ' + exp + ')'
-          throw new Error(desc ? msg + ' ' + desc : msg);
+      try {
+        var a;
+        function checkLen(exp, desc) {
+          if (a.length !== exp) {
+            var msg = 'a.length === ' + a.length + ' (expected: ' + exp + ')'
+            throw new Error(desc ? msg + ' ' + desc : msg);
+          }
         }
-      }
-      // Empty array has length == 0
-      a = [];
-      checkLen(0, 'on empty array');
-      // Adding non-numeric properties does not increase length:
-      a['zero'] = 0;
-      checkLen(0, 'after setting non-index property on []');
-      // Adding numeric properties >= length does increase length:
-      for (var i = 0; i < 5; i++) {
-        a[i] = i;
-        checkLen(i + 1, 'after setting a[' + i + ']');
-      }
-      // .length works propery even for large, sparse arrays, and even
-      // if values are undefined:
-      for (i = 3; i <= 31; i++) {
-        var idx = (1 << i) >>> 0;  // >>> 0 converts int32 to uint32
-        a[idx] = undefined;
-        checkLen(idx + 1, 'after setting a[' + idx + ']');
-      }
-      // Adding numeric properties < length does not increase length:
-      a[idx - 1] = 'not the largest';
-      checkLen(idx + 1, 'after setting non-largest element');
-      // Verify behaviour around largest possible index:
-      a[0xfffffffd] = null;
-      checkLen(0xfffffffe);
-      a[0xfffffffe] = null;
-      checkLen(0xffffffff);
-      a[0xffffffff] = null;  // Not an index.
-      checkLen(0xffffffff);  // Unchanged.
-      a[0x100000000] = null; // Not an index.
-      checkLen(0xffffffff);  // Unchanged.
-      function checkIdx(idx, exp, desc) {
-        var r = a.hasOwnProperty(idx);
-        if (r !== exp) {
-          var msg = 'a.hasOwnProperty(' + idx + ') === ' + r;
-          throw new Error(desc ? msg + ' ' + desc : msg);
+        // Empty array has length == 0
+        a = [];
+        checkLen(0, 'on empty array');
+        // Adding non-numeric properties does not increase length:
+        a['zero'] = 0;
+        checkLen(0, 'after setting non-index property on []');
+        // Adding numeric properties >= length does increase length:
+        for (var i = 0; i < 5; i++) {
+          a[i] = i;
+          checkLen(i + 1, 'after setting a[' + i + ']');
         }
-      }
-      // Setting length to existing value should have no effect:
-      a.length = 0xffffffff;
-      checkIdx(0xfffffffd, true);
-      checkIdx(0xfffffffe, true);
-      checkIdx(0xffffffff, true);
-      checkIdx(0x100000000, true);
-      // Setting length one less than maximum should remove largest
-      // index, but leave properties with keys too large to be indexes:
-      a.length = 0xfffffffe;
-      checkIdx(0xfffffffd, true);
-      checkIdx(0xfffffffe, false);
-      checkIdx(0xffffffff, true);
-      checkIdx(0x100000000, true);
-      // Setting length to zero should remove all index properties:
-      a.length = 0;
-      for (var key in a) {
-        if (!a.hasOwnProperty(key)) {
-          continue;
+        // .length works propery even for large, sparse arrays, and even
+        // if values are undefined:
+        for (i = 3; i <= 31; i++) {
+          var idx = (1 << i) >>> 0;  // >>> 0 converts int32 to uint32
+          a[idx] = undefined;
+          checkLen(idx + 1, 'after setting a[' + idx + ']');
         }
-        if (String(key >>> 0) === key && (key >>> 0) !== 0xffffffff) {
+        // Adding numeric properties < length does not increase length:
+        a[idx - 1] = 'not the largest';
+        checkLen(idx + 1, 'after setting non-largest element');
+        // Verify behaviour around largest possible index:
+        a[0xfffffffd] = null;
+        checkLen(0xfffffffe);
+        a[0xfffffffe] = null;
+        checkLen(0xffffffff);
+        a[0xffffffff] = null;  // Not an index.
+        checkLen(0xffffffff);  // Unchanged.
+        a[0x100000000] = null; // Not an index.
+        checkLen(0xffffffff);  // Unchanged.
+        function checkIdx(idx, exp, desc) {
+          var r = a.hasOwnProperty(idx);
+          if (r !== exp) {
+            var msg = 'a.hasOwnProperty(' + idx + ') === ' + r;
+            throw new Error(desc ? msg + ' ' + desc : msg);
+          }
+        }
+        // Setting length to existing value should have no effect:
+        a.length = 0xffffffff;
+        checkIdx(0xfffffffd, true);
+        checkIdx(0xfffffffe, true);
+        checkIdx(0xffffffff, true);
+        checkIdx(0x100000000, true);
+        // Setting length one less than maximum should remove largest
+        // index, but leave properties with keys too large to be indexes:
+        a.length = 0xfffffffe;
+        checkIdx(0xfffffffd, true);
+        checkIdx(0xfffffffe, false);
+        checkIdx(0xffffffff, true);
+        checkIdx(0x100000000, true);
+        // Setting length to zero should remove all index properties:
+        a.length = 0;
+        for (var key in a) {
+          if (!a.hasOwnProperty(key)) {
+            continue;
+          }
+          if (String(key >>> 0) === key && (key >>> 0) !== 0xffffffff) {
+            throw new Error(
+                'Setting a.length = 0 failed to remove property ' + key);
+          }
+        }
+        // Make sure we didn't wipe everything!
+        if (Object.getOwnPropertyNames(a).length !== 4) {
           throw new Error(
-              'Setting a.length = 0 failed to remove property ' + key);
+              'Setting .length == 0 removed some non-index properties');
         }
+        'OK';
+      } catch (e) {
+        String(e);
       }
-      // Make sure we didn't wipe everything!
-      if (Object.getOwnPropertyNames(a).length !== 4) {
-        throw new Error(
-            'Setting .length == 0 removed some non-index properties');
-      }
-      'OK';
-    } catch (e) {
-      String(e);
-    }
     `,
     expected: 'OK'
   },
   {
     name: 'arrayLengthWithNonWritableProps',
     src: `
-    var a = [];
-    Object.defineProperty(a, 0,
-        {value: 'hi', writable: false, configurable: true});
-    a.length = 0;
-    a[0] === undefined && a.length === 0;
+      var a = [];
+      Object.defineProperty(a, 0,
+          {value: 'hi', writable: false, configurable: true});
+      a.length = 0;
+      a[0] === undefined && a.length === 0;
     `,
     expected: true
   },
   {
     name: 'arrayLengthWithNonConfigurableProps',
     src: `
-    var a = [];
-    Object.defineProperty(a, 0,
-        {value: 'hi', writable: false, configurable: false});
-    try {
-      a.length = 0;
-    } catch (e) {
-      e.name;
-    }
+      var a = [];
+      Object.defineProperty(a, 0,
+          {value: 'hi', writable: false, configurable: false});
+      try {
+        a.length = 0;
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -662,34 +662,34 @@ module.exports = [
   {
     name: 'unaryTypeof',
     src: `
-    var tests = [
-      [undefined, 'undefined'],
-      [null, 'object'],
-      [false, 'boolean'],
-      [0, 'number'],
-      ['', 'string'],
-      [{}, 'object'],
-      [[], 'object'],
-      [function() {}, 'function'],
-    ];
-    var ok = 0;
-    for (var i = 0; i < tests.length; i++) {
-      if (typeof tests[i][0] === tests[i][1]) {
-        ok++;
+      var tests = [
+        [undefined, 'undefined'],
+        [null, 'object'],
+        [false, 'boolean'],
+        [0, 'number'],
+        ['', 'string'],
+        [{}, 'object'],
+        [[], 'object'],
+        [function() {}, 'function'],
+      ];
+      var ok = 0;
+      for (var i = 0; i < tests.length; i++) {
+        if (typeof tests[i][0] === tests[i][1]) {
+          ok++;
+        }
       }
-    }
-    (ok === tests.length) ? 'pass' : 'fail';
+      (ok === tests.length) ? 'pass' : 'fail';
     `,
     expected: 'pass'
   },
   {
     name: 'unaryTypeofUndeclared',
     src: `
-    try {
-      typeof undeclaredVar;
-    } catch (e) {
-      'whoops!'
-    }
+      try {
+        typeof undeclaredVar;
+      } catch (e) {
+        'whoops!'
+      }
     `,
     expected: 'undefined'
   },
@@ -701,9 +701,9 @@ module.exports = [
   {
     name: 'binaryInParent',
     src: `
-    var p = {foo: 'bar'};
-    var o = Object.create(p);
-    'foo' in o && !('bar' in o);
+      var p = {foo: 'bar'};
+      var o = Object.create(p);
+      'foo' in o && !('bar' in o);
     `,
     expected: true
   },
@@ -714,108 +714,108 @@ module.exports = [
   {
     name: 'binaryInStringLength',
     src: `
-    try {
-      'length' in '';
-    } catch (e) {
-      e.name;
-    }
+      try {
+        'length' in '';
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'instanceofBasics',
     src: `
-    function F(){}
-    var f = new F;
-    f instanceof F && f instanceof Object && !(f.prototype instanceof F);
+      function F(){}
+      var f = new F;
+      f instanceof F && f instanceof Object && !(f.prototype instanceof F);
     `,
     expected: true
   },
   {
     name: 'instanceofNonObjectLHS',
     src: `
-    function F() {}
-    F.prototype = null;
-    42 instanceof F;
+      function F() {}
+      F.prototype = null;
+      42 instanceof F;
     `,
     expected: false
   },
   {
     name: 'instanceofNonFunctionRHS',
     src: `
-    try {
-      ({}) instanceof 0;
-    } catch (e) {
-      e.name;
-    }
+      try {
+        ({}) instanceof 0;
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'instanceofNonObjectPrototype',
     src: `
-    function F() {};
-    F.prototype = 'hello';
-    try {
-      ({}) instanceof F;
-    } catch (e) {
-      e.name;
-    }
+      function F() {};
+      F.prototype = 'hello';
+      try {
+        ({}) instanceof F;
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'undefined.foo',
     src: `
-    try {
-      undefined.foo;
-    } catch (e) {
-      e.name;
-    }
+      try {
+        undefined.foo;
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'undefined.foo = ...',
     src: `
-    try {
-      var c = 0;
-      undefined.foo = c++;
-    } catch (e) {
-      e.name + ',' + c;
-    }
+      try {
+        var c = 0;
+        undefined.foo = c++;
+      } catch (e) {
+        e.name + ',' + c;
+      }
     `,
     expected: 'TypeError,0'
   },
   {
     name: 'null.foo',
     src: `
-    try {
-      null.foo;
-    } catch (e) {
-      e.name;
-    }
+      try {
+        null.foo;
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'null.foo = ...',
     src: `
-    try {
-      var c = 0;
-      null.foo = c++;
-    } catch (e) {
-      e.name + ',' + c;
-    }
+      try {
+        var c = 0;
+        null.foo = c++;
+      } catch (e) {
+        e.name + ',' + c;
+      }
     `,
     expected: 'TypeError,0'
   },
   {
     name: 'delete',
     src: `
-    var o = {foo: 'bar'};
-    (delete o.quux) + ('foo' in o) + (delete o.foo) +
-        !('foo' in o) + (delete o.foo);
+      var o = {foo: 'bar'};
+      (delete o.quux) + ('foo' in o) + (delete o.foo) +
+          !('foo' in o) + (delete o.foo);
     `,
     expected: 5
   },
@@ -833,36 +833,36 @@ module.exports = [
   {
     name: 'deleteOwnFromPrimitive',
     src: `
-    try {
-      delete 'hello'.length;
-    } catch (e) {
-      e.name;
-    }
+      try {
+        delete 'hello'.length;
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'funcDecl',
     src: `
-    var v;
-    function f() {
-      v = 75;
-    }
-    f();
-    v;
+      var v;
+      function f() {
+        v = 75;
+      }
+      f();
+      v;
     `,
     expected: 75
   },
   {
     name: 'namedFunctionExpression',
     src: `
-    var f = function half(x) {
-      if (x < 100) {
-        return x;
-      }
-      return half(x / 2);
-    };
-    f(152)
+      var f = function half(x) {
+        if (x < 100) {
+          return x;
+        }
+        return half(x / 2);
+      };
+      f(152)
     `,
     expected: 76
   },
@@ -879,141 +879,141 @@ module.exports = [
   {
     name: 'namedFunExpNameBindingImmutable',
     src: `
-    var f = function foo() {
-      try {
-        foo = null;
-      } catch (e) {
-        return e.name;
-      }
-    };
-    f();
+      var f = function foo() {
+        try {
+          foo = null;
+        } catch (e) {
+          return e.name;
+        }
+      };
+      f();
     `,
     expected: 'TypeError'
   },
   {
     name: 'namedFunExpNameBindingShadowedByParam',
     src: `
-    var f = function foo(foo) {
-      foo += 0.1;  // Verify mutability.
-      return foo;
-    };
-    f(76);
+      var f = function foo(foo) {
+        foo += 0.1;  // Verify mutability.
+        return foo;
+      };
+      f(76);
     `,
     expected: 76.1
   },
   {
     name: 'namedFunExpNameBindingShadowedByVar',
     src: `
-    var f = function foo() {
-      var foo;
-      foo = 76.2;  // Verify mutability.
-      return foo;
-    };
-    f();
+      var f = function foo() {
+        var foo;
+        foo = 76.2;  // Verify mutability.
+        return foo;
+      };
+      f();
     `,
     expected: 76.2
   },
   {
     name: 'closureIndependence',
     src: `
-    function makeAdder(x) {
-      return function(y) {return x + y;};
-    }
-    var plus3 = makeAdder(3);
-    var plus4 = makeAdder(4);
-    plus3(plus4(70));
+      function makeAdder(x) {
+        return function(y) {return x + y;};
+      }
+      var plus3 = makeAdder(3);
+      var plus4 = makeAdder(4);
+      plus3(plus4(70));
     `,
     expected: 77
   },
   {
     name: 'internalObjectToString',
     src: `
-    var o = {};
-    o[{}] = null;
-    for(var key in o) {
-      key;
-    }
+      var o = {};
+      o[{}] = null;
+      for(var key in o) {
+        key;
+      }
     `,
     expected: '[object Object]'
   },
   {
     name: 'internalFunctionToString',
     src: `
-    var o = {}, s, f = function(){};
-    o[f] = null;
-    for(var key in o) {
-      s = key;
-    }
-    /^function.*\(.*\).*{[^]*}$/.test(s);
+      var o = {}, s, f = function(){};
+      o[f] = null;
+      for(var key in o) {
+        s = key;
+      }
+      /^function.*\(.*\).*{[^]*}$/.test(s);
     `,
     expected: true
   },
   {
     name: 'internalNativeFuncToString',
     src: `
-    var o = {}, s, f = Object.create;
-    o[f] = null;
-    for(var key in o) {
-      s = key;
-    }
-    /^function.*\(.*\).*{[^]*}$/.test(s);
+      var o = {}, s, f = Object.create;
+      o[f] = null;
+      for(var key in o) {
+        s = key;
+      }
+      /^function.*\(.*\).*{[^]*}$/.test(s);
     `,
     expected: true
   },
   {
     name: 'internalArrayToString',
     src: `
-    var o = {};
-    o[[1, 2, 3]] = null;
-    for(var key in o) {
-      key;
-    }
+      var o = {};
+      o[[1, 2, 3]] = null;
+      for(var key in o) {
+        key;
+      }
     `,
     expected: '1,2,3'
   },
   {
     name: 'internalDateToString',
     src: `
-    var o = {};
-    o[new Date(0)] = null;
-    for(var key in o) {
-      key;
-    }
+      var o = {};
+      o[new Date(0)] = null;
+      for(var key in o) {
+        key;
+      }
     `,
     expected: (new Date(0)).toString()
   },
   {
     name: 'internalRegExpToString',
     src: `
-    var o = {};
-    o[/foo/g] = null;
-    for(var key in o) {
-      key;
-    }
+      var o = {};
+      o[/foo/g] = null;
+      for(var key in o) {
+        key;
+      }
     `,
     expected: '/foo/g'
   },
   {
     name: 'internalErrorToString',
     src: `
-    var o = {};
-    o[Error('oops')] = null;
-    for(var key in o) {
-      key;
-    }
+      var o = {};
+      o[Error('oops')] = null;
+      for(var key in o) {
+        key;
+      }
     `,
     expected: 'Error: oops'
   },
   {
     name: 'internalArgumentsToString',
     src: `
-    var o = {};
-    (function() {
-      o[arguments] = null;
-    })();
-    for(var key in o) {
-      key;
-    }
+      var o = {};
+      (function() {
+        o[arguments] = null;
+      })();
+      for(var key in o) {
+        key;
+      }
     `,
     expected: '[object Arguments]'
   },
@@ -1024,28 +1024,28 @@ module.exports = [
   {
     name: 'newExpression',
     src: `
-    function T(x, y) {this.sum += x + y;};
-    T.prototype = {sum: 70}
-    var t = new T(7, 0.7);
-    t.sum;
+      function T(x, y) {this.sum += x + y;};
+      T.prototype = {sum: 70}
+      var t = new T(7, 0.7);
+      t.sum;
     `,
     expected: 77.7
   },
   {
     name: 'newExpressionReturnObj',
     src: `
-    function T() {return {};};
-    T.prototype = {p: 'the prototype'};
-    (new T).p;
+      function T() {return {};};
+      T.prototype = {p: 'the prototype'};
+      (new T).p;
     `,
     expected: undefined
   },
   {
     name: 'newExpressionReturnPrimitive',
     src: `
-    function T() {return 0;};
-    T.prototype = {p: 'the prototype'};
-    (new T).p;
+      function T() {return 0;};
+      T.prototype = {p: 'the prototype'};
+      (new T).p;
     `,
     expected: 'the prototype'
   },
@@ -1061,28 +1061,28 @@ module.exports = [
   {
     name: 'evalIndirectNoSeeEnclosing',
     src: `
-    (function() {
-      var n = 77.77, gEval = eval;
-      try {
-        gEval('n');
-      } catch (e) {
-        return e.name;
-      }
-    })();
+      (function() {
+        var n = 77.77, gEval = eval;
+        try {
+          gEval('n');
+        } catch (e) {
+          return e.name;
+        }
+      })();
     `,
     expected: 'ReferenceError'
   },
   {
     name: 'evalIndirectNoSeeEnclosing2',
     src: `
-    (function() {
-      var n = 77.77;
-      try {
-        (function() {return eval;})()('n');
-      } catch (e) {
-        return e.name;
-      }
-    })();
+      (function() {
+        var n = 77.77;
+        try {
+          (function() {return eval;})()('n');
+        } catch (e) {
+          return e.name;
+        }
+      })();
     `,
     expected: 'ReferenceError'
   },
@@ -1112,52 +1112,52 @@ module.exports = [
   {
     name: 'callEvalOrder',
     src: `
-    var r = '';
-    function log(x) {
-      r += x;
-      return function() {};
-    };
-    (log('f'))(log('a'), log('b'), log('c'));
-    r;
+      var r = '';
+      function log(x) {
+        r += x;
+        return function() {};
+      };
+      (log('f'))(log('a'), log('b'), log('c'));
+      r;
     `,
     expected: 'fabc'
   },
   {
     name: 'callEvalArgsBeforeCallability',
     src: `
-    try {
-      var invalid = undefined;
-      function t() {throw {name: 'args'};};
-      invalid(t());
-    } catch(e) {
-      e.name;
-    }
+      try {
+        var invalid = undefined;
+        function t() {throw {name: 'args'};};
+        invalid(t());
+      } catch(e) {
+        e.name;
+      }
     `,
     expected: 'args'
   },
   {
     name: 'callNonCallable',
     src: `
-    var tests = [
-      undefined,
-      null,
-      false,
-      42,
-      'hello',
-      Object.create(Function.prototype),
-    ];
-    var ok = 0;
-    for (var i = 0; i < tests.length; i++) {
-      try {
-        tests[i]();
-      } catch (e) {
-        var r = e;
-        if (e.name === 'TypeError') {
-          ok++;
+      var tests = [
+        undefined,
+        null,
+        false,
+        42,
+        'hello',
+        Object.create(Function.prototype),
+      ];
+      var ok = 0;
+      for (var i = 0; i < tests.length; i++) {
+        try {
+          tests[i]();
+        } catch (e) {
+          var r = e;
+          if (e.name === 'TypeError') {
+            ok++;
+          }
         }
       }
-    }
-    (ok === tests.length) ? 'pass' : 'fail';
+      (ok === tests.length) ? 'pass' : 'fail';
     `,
     expected: 'pass'
   },
@@ -1166,34 +1166,34 @@ module.exports = [
   {
     name: 'Object.defineProperty()',
     src: `
-    try {
-      Object.defineProperty();
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.defineProperty();
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.defineProperty non-object',
     src: `
-    try {
-      Object.defineProperty('not an object', 'foo', {});
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.defineProperty('not an object', 'foo', {});
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.defineProperty bad descriptor',
     src: `
-    var o = {};
-    try {
-      Object.defineProperty(o, 'foo', 'not an object');
-    } catch (e) {
-      e.name;
-    }
+      var o = {};
+      try {
+        Object.defineProperty(o, 'foo', 'not an object');
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -1201,46 +1201,46 @@ module.exports = [
   {
     name: 'Object.defineProperty',
     src: `
-    var o = {foo: 50}, r = 0;
-    Object.defineProperty(o, 'bar', {
-      writable: true,
-      enumerable: true,
-      configurable: true,
-      value: 0
-    });
-    o.bar = 20;
-    Object.defineProperty(o, 'baz', {
-      writable: true,
-      enumerable: true,
-      configurable: false
-    });
-    Object.defineProperty(o, 'baz', {
-      value: 4,
-    });
-    Object.defineProperty(o, 'quux', {
-      enumerable: false,
-      value: 13
-    });
-    for (var k in o) {
-      r += o[k];
-    }
-    r += Object.getOwnPropertyNames(o).length;
-    r;
+      var o = {foo: 50}, r = 0;
+      Object.defineProperty(o, 'bar', {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value: 0
+      });
+      o.bar = 20;
+      Object.defineProperty(o, 'baz', {
+        writable: true,
+        enumerable: true,
+        configurable: false
+      });
+      Object.defineProperty(o, 'baz', {
+        value: 4,
+      });
+      Object.defineProperty(o, 'quux', {
+        enumerable: false,
+        value: 13
+      });
+      for (var k in o) {
+        r += o[k];
+      }
+      r += Object.getOwnPropertyNames(o).length;
+      r;
     `,
     expected: 78
   },
   {
     name: 'Object.getPrototypeOf(null) and undefined',
     src: `
-    var r = '', prims = [null, undefined];
-    for (var i = 0; i < prims.length; i++) {
-      try {
-        Object.getPrototypeOf(prims[i]);
-      } catch (e) {
-        r += e.name;
+      var r = '', prims = [null, undefined];
+      for (var i = 0; i < prims.length; i++) {
+        try {
+          Object.getPrototypeOf(prims[i]);
+        } catch (e) {
+          r += e.name;
+        }
       }
-    }
-    r;
+      r;
     `,
     expected: 'TypeErrorTypeError'
   },
@@ -1248,88 +1248,88 @@ module.exports = [
   {
     name: 'Object.getPrototypeOf primitives',
     src: `
-    Object.getPrototypeOf(true) === Boolean.prototype &&
-    Object.getPrototypeOf(1337) === Number.prototype &&
-    Object.getPrototypeOf('hi') === String.prototype;
+      Object.getPrototypeOf(true) === Boolean.prototype &&
+      Object.getPrototypeOf(1337) === Number.prototype &&
+      Object.getPrototypeOf('hi') === String.prototype;
     `,
     expected: true
   },
   {
     name: 'Object.setPrototypeOf(null, ...) and undefined',
     src: `
-    var r = '', prims = [null, undefined];
-    for (var i = 0; i < prims.length; i++) {
-      try {
-        Object.setPrototypeOf(prims[i], null);
-      } catch (e) {
-        r += e.name;
+      var r = '', prims = [null, undefined];
+      for (var i = 0; i < prims.length; i++) {
+        try {
+          Object.setPrototypeOf(prims[i], null);
+        } catch (e) {
+          r += e.name;
+        }
       }
-    }
-    r;
+      r;
     `,
     expected: 'TypeErrorTypeError'
   },
   {
     name: 'Object.setPrototypeOf primitives',
     src: `
-    Object.setPrototypeOf(true, null) === true &&
-    Object.setPrototypeOf(1337, null) === 1337 &&
-    Object.setPrototypeOf('hi', null) === 'hi';
+      Object.setPrototypeOf(true, null) === true &&
+      Object.setPrototypeOf(1337, null) === 1337 &&
+      Object.setPrototypeOf('hi', null) === 'hi';
     `,
     expected: true
   },
   {
     name: 'Object.setPrototypeOf',
     src: `
-    var o = {parent: 'o'};
-    var p = {parent: 'p'};
-    var q = Object.create(o);
-    Object.setPrototypeOf(q, p) === q &&
-        Object.getPrototypeOf(q) === p && q.parent;
+      var o = {parent: 'o'};
+      var p = {parent: 'p'};
+      var q = Object.create(o);
+      Object.setPrototypeOf(q, p) === q &&
+          Object.getPrototypeOf(q) === p && q.parent;
     `,
     expected: 'p'
   },
   {
     name: 'Object.setPrototypeOf(..., null)',
     src: `
-    var o = {parent: 'o'};
-    var q = Object.create(o);
-    Object.setPrototypeOf(q, null) === q && Object.getPrototypeOf(q);
+      var o = {parent: 'o'};
+      var q = Object.create(o);
+      Object.setPrototypeOf(q, null) === q && Object.getPrototypeOf(q);
     `,
     expected: null
   },
   {
     name: 'Object.setPrototypeOf circular',
     src: `
-    var o = {};
-    var p = Object.create(o);
-    try {
-      Object.setPrototypeOf(o, p);
-    } catch (e) {
-      e.name;
-    }
+      var o = {};
+      var p = Object.create(o);
+      try {
+        Object.setPrototypeOf(o, p);
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.create()',
     src: `
-    try {
-      Object.create();
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.create();
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.create non-object prototype',
     src: `
-    try {
-      Object.create(42);
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.create(42);
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -1341,31 +1341,31 @@ module.exports = [
   {
     name: 'Object.create',
     src: `
-    var o = Object.create({foo: 79});
-    delete o.foo
-    o.foo;
+      var o = Object.create({foo: 79});
+      delete o.foo
+      o.foo;
     `,
     expected: 79
   },
   {
     name: 'Object.getOwnPropertyDescriptor()',
     src: `
-    try {
-      Object.getOwnPropertyDescriptor();
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.getOwnPropertyDescriptor();
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.getOwnPropertyDescriptor non-object',
     src: `
-    try {
-      Object.getOwnPropertyDescriptor('not an object', 'foo');
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.getOwnPropertyDescriptor('not an object', 'foo');
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -1377,36 +1377,36 @@ module.exports = [
   {
     name: 'Object.getOwnPropertyDescriptor',
     src: `
-    var o = {}, r = 0;
-    Object.defineProperty(o, 'foo', {value: 'bar'});
-    var desc = Object.getOwnPropertyDescriptor(o, 'foo');
-    desc.value === o.foo &&
-        !desc.writable && !desc.enumerable && !desc.configurable;
+      var o = {}, r = 0;
+      Object.defineProperty(o, 'foo', {value: 'bar'});
+      var desc = Object.getOwnPropertyDescriptor(o, 'foo');
+      desc.value === o.foo &&
+          !desc.writable && !desc.enumerable && !desc.configurable;
     `,
     expected: true
   },
   {
     name: 'Object.getOwnPropertyNames()',
     src: `
-    try {
-      Object.getOwnPropertyNames();
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.getOwnPropertyNames();
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.getOwnPropertyNames string',
     src: `
-    var i, r = 0, names = Object.getOwnPropertyNames('foo');
-    for (i = 0; i < names.length; i++) {
-      if (names[i] === 'length') {
-        r += 10;
-      } else {
-        r += Number(names[i]) + 1;
+      var i, r = 0, names = Object.getOwnPropertyNames('foo');
+      for (i = 0; i < names.length; i++) {
+        if (names[i] === 'length') {
+          r += 10;
+        } else {
+          r += Number(names[i]) + 1;
+        }
       }
-    }
     `,
     expected: 16
   },
@@ -1421,118 +1421,118 @@ module.exports = [
   {
     name: 'Object.getOwnPropertyNames(null)',
     src: `
-    try {
-      Object.getOwnPropertyNames(null).length;
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.getOwnPropertyNames(null).length;
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.getOwnPropertyNames(undefined)',
     src: `
-    try {
-      Object.getOwnPropertyNames(undefined).length;
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.getOwnPropertyNames(undefined).length;
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.getOwnPropertyNames',
     src: `
-    var o = Object.create({baz: 999});
-    o.foo = 42;
-    Object.defineProperty(o, 'bar', {value: 38});
-    var keys = Object.getOwnPropertyNames(o);
-    var r = 0;
-    for (var i = 0; i < keys.length; i++) {
-      r += o[keys[i]];
-    }
-    r;
+      var o = Object.create({baz: 999});
+      o.foo = 42;
+      Object.defineProperty(o, 'bar', {value: 38});
+      var keys = Object.getOwnPropertyNames(o);
+      var r = 0;
+      for (var i = 0; i < keys.length; i++) {
+        r += o[keys[i]];
+      }
+      r;
     `,
     expected: 80
   },
   {
     name: 'Object.defineProperties()',
     src: `
-    try {
-      Object.defineProperties();
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.defineProperties();
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.defineProperties non-object',
     src: `
-    try {
-      Object.defineProperties('not an object', {});
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.defineProperties('not an object', {});
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.defineProperties non-object props',
     src: `
-    try {
-      Object.defineProperties({}, undefined);
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.defineProperties({}, undefined);
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.defineProperties bad descriptor',
     src: `
-    var o = {};
-    try {
-      Object.defineProperties(o, {foo: 'not an object'});
-    } catch (e) {
-      e.name;
-    }
+      var o = {};
+      try {
+        Object.defineProperties(o, {foo: 'not an object'});
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.defineProperties',
     src: `
-    var o = {foo: 70}, r = 0;
-    Object.defineProperties(o, {
-        bar: {
-            writable: true,
-            enumerable: true,
-            configurable: true,
-            value: 8 },
-        baz: {value: 999}});
-    for (var k in o) {
-      r += o[k];
-    }
-    r + Object.getOwnPropertyNames(o).length;
+      var o = {foo: 70}, r = 0;
+      Object.defineProperties(o, {
+          bar: {
+              writable: true,
+              enumerable: true,
+              configurable: true,
+              value: 8 },
+          baz: {value: 999}});
+      for (var k in o) {
+        r += o[k];
+      }
+      r + Object.getOwnPropertyNames(o).length;
     `,
     expected: 81
   },
   {
     name: 'Object.create(..., properties)',
     src: `
-    var o = Object.create({foo: 70}, {
-        bar: {
-            writable: true,
-            enumerable: true,
-            configurable: true,
-            value: 10 },
-        baz: {value: 999}});
-    var r = 0;
-    for (var k in o) {
-      r += o[k];
-    }
-    r + Object.getOwnPropertyNames(o).length;
+      var o = Object.create({foo: 70}, {
+          bar: {
+              writable: true,
+              enumerable: true,
+              configurable: true,
+              value: 10 },
+          baz: {value: 999}});
+      var r = 0;
+      for (var k in o) {
+        r += o[k];
+      }
+      r + Object.getOwnPropertyNames(o).length;
     `,
     expected: 82
   },
@@ -1544,51 +1544,52 @@ module.exports = [
   {
     name: 'Object.protoype.hasOwnProperty',
     src: `
-    var o = Object.create({baz: 999});
-    o.foo = 42;
-    Object.defineProperty(o, 'bar', {value: 41, enumerable: true});
-    var r = 0;
-    for (var key in o) {
-      if (!o.hasOwnProperty(key)) continue;
-      r += o[key];
-    }
-    r;
+      var o = Object.create({baz: 999});
+      o.foo = 42;
+      Object.defineProperty(o, 'bar', {value: 41, enumerable: true});
+      var r = 0;
+      for (var key in o) {
+        if (!o.hasOwnProperty(key)) continue;
+        r += o[key];
+      }
+      r;
     `,
     expected: 83
   },
   {
     name: 'Object.protoype.isPrototypeOf primitives',
     src: `
-    Boolean.prototype.isPrototypeOf(false) ||
-    Number.prototype.isPrototypeOf(0) ||
-    String.prototype.isPrototypeOf('') ||
-    Object.prototype.isPrototypeOf.call(false, false) ||
-    Object.prototype.isPrototypeOf.call(0, 0) ||
-    Object.prototype.isPrototypeOf.call('', '') ||
-    Object.prototype.isPrototypeOf.call(null, null) ||
-    Object.prototype.isPrototypeOf.call(undefined, undefined);
+      Boolean.prototype.isPrototypeOf(false) ||
+      Number.prototype.isPrototypeOf(0) ||
+      String.prototype.isPrototypeOf('') ||
+      Object.prototype.isPrototypeOf.call(false, false) ||
+      Object.prototype.isPrototypeOf.call(0, 0) ||
+      Object.prototype.isPrototypeOf.call('', '') ||
+      Object.prototype.isPrototypeOf.call(null, null) ||
+      Object.prototype.isPrototypeOf.call(undefined, undefined);
     `,
     expected: false
   },
   {
     name: 'Object.protoype.isPrototypeOf.call(null, ...)',
     src: `
-    try {
-      Object.prototype.isPrototypeOf.call(null, Object.create(null));
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.prototype.isPrototypeOf.call(null, Object.create(null));
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.protoype.isPrototypeOf.call(undefined, ...)',
     src: `
-    try {
-      Object.prototype.isPrototypeOf.call(undefined, Object.create(undefined));
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Object.prototype.isPrototypeOf
+          .call(undefined, Object.create(undefined));
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -1604,52 +1605,52 @@ module.exports = [
   {
     name: 'Object.protoype.isPrototypeOf related',
     src: `
-    var g = {};
-    var p = Object.create(g);
-    var o = Object.create(p);
-    !o.isPrototypeOf({}) &&
-    g.isPrototypeOf(o) && p.isPrototypeOf(o) &&
-    !o.isPrototypeOf(p) && !o.isPrototypeOf(g);
+      var g = {};
+      var p = Object.create(g);
+      var o = Object.create(p);
+      !o.isPrototypeOf({}) &&
+      g.isPrototypeOf(o) && p.isPrototypeOf(o) &&
+      !o.isPrototypeOf(p) && !o.isPrototypeOf(g);
     `,
     expected: true
   },
   {
     name: 'Object.protoype.propertyIsEnumerable(null)',
     src: `
-    try {
-      Object.prototype.propertyIsEnumerable.call(null, '');
-    } catch(e) {
-      e.name;
-    }
+      try {
+        Object.prototype.propertyIsEnumerable.call(null, '');
+      } catch(e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'ObjectProtoypePropertyIsEnumerableUndefined',
     src: `
-    try {
-      Object.prototype.propertyIsEnumerable.call(undefined, '');
-    } catch(e) {
-      e.name;
-    }
+      try {
+        Object.prototype.propertyIsEnumerable.call(undefined, '');
+      } catch(e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Object.protoype.propertyIsEnumerable primitives',
     src: `
-    var OppIE = Object.prototype.propertyIsEnumerable;
-    OppIE.call('foo', '0') && !OppIE.call('foo', 'length');
+      var OppIE = Object.prototype.propertyIsEnumerable;
+      OppIE.call('foo', '0') && !OppIE.call('foo', 'length');
     `,
     expected: true
   },
   {
     name: 'Object.protoype.propertyIsEnumerable',
     src: `
-    var o = {foo: 'foo'};
-    Object.defineProperty(o, 'bar', {value: 'bar', enumerable: false});
-    o.propertyIsEnumerable('foo') && !o.propertyIsEnumerable('bar') &&
-        !o.propertyIsEnumerable('baz');
+      var o = {foo: 'foo'};
+      Object.defineProperty(o, 'bar', {value: 'bar', enumerable: false});
+      o.propertyIsEnumerable('foo') && !o.propertyIsEnumerable('bar') &&
+          !o.propertyIsEnumerable('baz');
     `,
     expected: true
   },
@@ -1704,107 +1705,107 @@ module.exports = [
   {
     name: 'Function.prototype.toString applied to non-fucntion throws',
     src: `
-    try {
-      Function.prototype.toString.apply({});
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Function.prototype.toString.apply({});
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Function.prototype.apply non-function throws',
     src: `
-    var o = {};
-    o.apply = Function.prototype.apply;
-    try {
-      o.apply();
-    } catch (e) {
-      e.name;
-    }
+      var o = {};
+      o.apply = Function.prototype.apply;
+      try {
+        o.apply();
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Function.prototype.apply this',
     src: `
-    var o = {};
-    function f() {return this;}
-    f.apply(o, []) === o;
+      var o = {};
+      function f() {return this;}
+      f.apply(o, []) === o;
     `,
     expected: true
   },
   {
     name: 'Function.prototype.apply(..., undefined) or null',
     src: `
-    var n = 0;
-    function f() {n += arguments.length;}
-    f.apply(undefined, undefined);
-    f.apply(undefined, null);
-    n;
+      var n = 0;
+      function f() {n += arguments.length;}
+      f.apply(undefined, undefined);
+      f.apply(undefined, null);
+      n;
     `,
     expected: 0
   },
   {
     name: 'Function.prototype.apply(..., non-object)',
     src: `
-    try {
-      (function() {}).apply(undefined, 'not an object');
-    } catch (e) {
-      e.name;
-    }
+      try {
+        (function() {}).apply(undefined, 'not an object');
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Function.prototype.apply(..., sparse)',
     src: `
-    (function(a, b, c) {
-      if (!(1 in arguments)) {
-        throw new Error('Argument 1 missing');
-      }
-      return a + c;
-    }).apply(undefined, [1, , 3]);
+      (function(a, b, c) {
+        if (!(1 in arguments)) {
+          throw new Error('Argument 1 missing');
+        }
+        return a + c;
+      }).apply(undefined, [1, , 3]);
     `,
     expected: 4
   },
   {
     name: 'Function.prototype.apply(..., array-like)',
     src: `
-    (function(a, b, c) {
-      return a + b + c;
-    }).apply(undefined, {0: 1, 1: 2, 2: 3, length: 3});
+      (function(a, b, c) {
+        return a + b + c;
+      }).apply(undefined, {0: 1, 1: 2, 2: 3, length: 3});
     `,
     expected: 6
   },
   {
     name: 'Function.prototype.apply(..., non-array-like)',
     src: `
-    (function(a, b, c) {
-      return a + b + c;
-    }).apply(undefined, {0: 1, 1: 2, 2: 4});
+      (function(a, b, c) {
+        return a + b + c;
+      }).apply(undefined, {0: 1, 1: 2, 2: 4});
     `,
     expected: NaN  // Because undefined + undefined === NaN.
   },
   {
     name: 'Function.prototype.call non-function throws',
     src: `
-    var o = {};
-    o.call = Function.prototype.call;
-    try {
-      o.call();
-    } catch (e) {
-      e.name;
-    }
+      var o = {};
+      o.call = Function.prototype.call;
+      try {
+        o.call();
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Function.prototype.call this',
     src: `
-    var o = {};
-    function f() {return this;}
-    f.call(o) === o;
+      var o = {};
+      function f() {return this;}
+      f.call(o) === o;
     `,
     expected: true
   },
@@ -1816,34 +1817,34 @@ module.exports = [
   {
     name: 'Function.prototype.call',
     src: `
-    (function(a, b, c) {
-      if (!(1 in arguments)) {
-        throw new Error('Argument 1 missing');
-      }
-      return a + c;
-    }).call(undefined, 1, 2, 3);
+      (function(a, b, c) {
+        if (!(1 in arguments)) {
+          throw new Error('Argument 1 missing');
+        }
+        return a + c;
+      }).call(undefined, 1, 2, 3);
     `,
     expected: 4
   },
   {
     name: 'Function.prototype.bind non-function throws',
     src: `
-    var o = {};
-    o.bind = Function.prototype.bind;
-    try {
-      o.bind();
-    } catch (e) {
-      e.name;
-    }
+      var o = {};
+      o.bind = Function.prototype.bind;
+      try {
+        o.bind();
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'Function.prototype.bind this',
     src: `
-    var o = {};
-    function f() {return this;}
-    f.bind(o)() === o;
+      var o = {};
+      function f() {return this;}
+      f.bind(o)() === o;
     `,
     expected: true
   },
@@ -1855,46 +1856,46 @@ module.exports = [
   {
     name: 'Function.prototype.bind',
     src: `
-    var d = 4;
-    (function(a, b, c) {
-      return a + b + c + d;
-    }).bind(undefined, 1).bind(undefined, 2)(3);
+      var d = 4;
+      (function(a, b, c) {
+        return a + b + c + d;
+      }).bind(undefined, 1).bind(undefined, 2)(3);
     `,
     expected: 10
   },
   {
     name: 'Function.prototype.bind call BF',
     src: `
-    var constructed;
-    function Foo() {constructed = (this instanceof Foo)}
-    var f = Foo.bind();
-    f();
-    constructed;
+      var constructed;
+      function Foo() {constructed = (this instanceof Foo)}
+      var f = Foo.bind();
+      f();
+      constructed;
     `,
     expected: false
   },
   {
     name: 'Function.prototype.bind construct BF',
     src: `
-    var constructed;
-    function Foo() {constructed = (this instanceof Foo)}
-    var f = Foo.bind();
-    new f;
-    constructed;
+      var constructed;
+      function Foo() {constructed = (this instanceof Foo)}
+      var f = Foo.bind();
+      new f;
+      constructed;
     `,
     expected: true
   },
   {
     name: 'Function.prototype.call.bind construct BF',
     src: `
-    var invoked;
-    function Foo() {invoked = true};
-    var f = Foo.call.bind(Foo);
-    try {
-      new f;
-    } catch (e) {
-      !invoked && e.name;
-    }
+      var invoked;
+      function Foo() {invoked = true};
+      var f = Foo.call.bind(Foo);
+      try {
+        new f;
+      } catch (e) {
+        !invoked && e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -1902,12 +1903,12 @@ module.exports = [
   {
     name: 'Function.prototype.bind class constructor w/o new',
     src: `
-    var f = WeakMap.bind();  // Should be O.K.
-    try {
-      f();
-    } catch (e) {
-      e.name;
-    }
+      var f = WeakMap.bind();  // Should be O.K.
+      try {
+        f();
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -1927,24 +1928,24 @@ module.exports = [
   {
     name: 'newArray(/* number */)',
     src: `
-    var a = new Array(42);
-    Array.isArray(a) && !(0 in a) && !(41 in a) && a.length;
+      var a = new Array(42);
+      Array.isArray(a) && !(0 in a) && !(41 in a) && a.length;
     `,
     expected: 42
   },
   {
     name: 'new Array(/* non-number */)',
     src: `
-    var a = new Array('foo');
-    Array.isArray(a) && a.length === 1 && a[0];
+      var a = new Array('foo');
+      Array.isArray(a) && a.length === 1 && a[0];
     `,
     expected: 'foo'
   },
   {
     name: 'new Array(/* multiple args */)',
     src: `
-    var a = new Array(1, 2, 3);
-    Array.isArray(a) && a.length === 3 && String(a);
+      var a = new Array(1, 2, 3);
+      Array.isArray(a) && a.length === 3 && String(a);
     `,
     expected: '1,2,3'
   },
@@ -1967,27 +1968,27 @@ module.exports = [
   {
     name: 'Array.prototype.concat()',
     src: `
-        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
-        var c = a.concat();
-        a.length === 6 && c.length === 6 && c !== a && String(c);
+      var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+      var c = a.concat();
+      a.length === 6 && c.length === 6 && c !== a && String(c);
     `,
     expected: 'foo,bar,baz,,quux,quuux'
   },
   {
     name: 'Array.prototype.concat(...)',
     src: `
-        var o = {0: 'quux', 1: 'quuux', length: 2};
-        var c = [].concat(['foo', 'bar'], 'baz', undefined, o);
-        c.length === 5 && '3' in c && c[3] === undefined && String(c);
+      var o = {0: 'quux', 1: 'quuux', length: 2};
+      var c = [].concat(['foo', 'bar'], 'baz', undefined, o);
+      c.length === 5 && '3' in c && c[3] === undefined && String(c);
     `,
     expected: 'foo,bar,baz,,[object Object]'
   },
   {
     name: 'Array.prototype.concat.call(object, ...)',
     src: `
-        var o = {0: 'foo', 1: 'bar', length: 2};
-        var c = Array.prototype.concat.call(o, 'baz', [, 'quux', 'quuux']);
-        c.length === 5 && String(c);
+      var o = {0: 'foo', 1: 'bar', length: 2};
+      var c = Array.prototype.concat.call(o, 'baz', [, 'quux', 'quuux']);
+      c.length === 5 && String(c);
     `,
     expected: '[object Object],baz,,quux,quuux'
   },
@@ -2016,8 +2017,8 @@ module.exports = [
   {
     name: 'Array.prototype.includes.call(array-like, ...)',
     src: `
-    var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
-    Array.prototype.includes.call(o, 2);
+      var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
+      Array.prototype.includes.call(o, 2);
     `,
     expected: true
   },
@@ -2049,8 +2050,8 @@ module.exports = [
   {
     name: 'Array.prototype.indexOf.call(array-like, ...)',
     src: `
-    var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
-    Array.prototype.indexOf.call(o, 2);
+      var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
+      Array.prototype.indexOf.call(o, 2);
     `,
     expected: 1
   },
@@ -2062,10 +2063,10 @@ module.exports = [
   {
     name: 'Array.prototype.join cycle detection',
     src: `
-    var a = [1, , 3];
-    a[1] = a;
-    a.join('-');
-    "Didn't crash!";
+      var a = [1, , 3];
+      a[1] = a;
+      a.join('-');
+      "Didn't crash!";
     `,
     expected: 'Didn\'t crash!'
   },
@@ -2092,183 +2093,183 @@ module.exports = [
   {
     name: 'Array.prototype.lastIndexOf.call(array-like, ...)',
     src: `
-    var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
-    Array.prototype.lastIndexOf.call(o, 2);
+      var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
+      Array.prototype.lastIndexOf.call(o, 2);
     `,
     expected: 3
   },
   {
     name: 'Array.prototype.pop',
     src: `
-        var a = ['foo', 'bar', 'baz'];
-        var r = a.pop();
-        a.length === 2 && r;
+      var a = ['foo', 'bar', 'baz'];
+      var r = a.pop();
+      a.length === 2 && r;
     `,
     expected: 'baz'
   },
   {
     name: 'Array.prototype.pop empty array',
     src: `
-        var a = [];
-        var r = a.pop();
-        a.length === 0 && r;
+      var a = [];
+      var r = a.pop();
+      a.length === 0 && r;
     `,
     expected: undefined
   },
   {
     name: 'Array.prototype.pop.apply(array-like)',
     src: `
-        var o = {0: 'foo', 1: 'bar', 2: 'baz', length: 3};
-        var r = Array.prototype.pop.apply(o);
-        o.length === 2 && r;
+      var o = {0: 'foo', 1: 'bar', 2: 'baz', length: 3};
+      var r = Array.prototype.pop.apply(o);
+      o.length === 2 && r;
     `,
     expected: 'baz'
   },
   {
     name: 'Array.prototype.pop.apply(empty array-like)',
     src: `
-        var o = {length: 0};
-        var r = Array.prototype.pop.apply(o);
-        o.length === 0 && r;
+      var o = {length: 0};
+      var r = Array.prototype.pop.apply(o);
+      o.length === 0 && r;
     `,
     expected: undefined
   },
   {
     name: 'Array.prototype.pop.apply(huge array-like)',
     src: `
-        var o = {5000000000000000: 'foo',
-                 5000000000000001: 'quux',
-                 length: 5000000000000002};
-        var r = Array.prototype.pop.apply(o);
-        o.length === 5000000000000001 && o[5000000000000000] === 'foo' && r;
+      var o = {5000000000000000: 'foo',
+               5000000000000001: 'quux',
+               length: 5000000000000002};
+      var r = Array.prototype.pop.apply(o);
+      o.length === 5000000000000001 && o[5000000000000000] === 'foo' && r;
     `,
     expected: 'quux'
   },
   {
     name: 'Array.prototype.push',
     src: `
-        var a = [];
-        a.push('foo') === 1 && a.push('bar') === 2 &&
-            a.length === 2 && a[0] === 'foo' && a[1] === 'bar';
+      var a = [];
+      a.push('foo') === 1 && a.push('bar') === 2 &&
+          a.length === 2 && a[0] === 'foo' && a[1] === 'bar';
     `,
     expected: true
   },
   {
     name: 'Array.prototype.push.call(array-like, ...)',
     src: `
-        var o = {length: 0};
-        Array.prototype.push.call(o, 'foo') === 1 &&
-            Array.prototype.push.call(o, 'bar') === 2 &&
-            o.length === 2 && o[0] === 'foo' && o[1] === 'bar';
+      var o = {length: 0};
+      Array.prototype.push.call(o, 'foo') === 1 &&
+          Array.prototype.push.call(o, 'bar') === 2 &&
+          o.length === 2 && o[0] === 'foo' && o[1] === 'bar';
     `,
     expected: true
   },
   {
     name: 'Array.prototype.push.call(huge array-like, ...)',
     src: `
-        var o = {length: 5000000000000000};
-        var o = {length: 5000000000000000};
-        Array.prototype.push.call(o, 'foo') === 5000000000000001 &&
-            Array.prototype.push.call(o, 'bar') === 5000000000000002 &&
-            o[5000000000000000] === 'foo' && o[5000000000000001] === 'bar' &&
-            o.length === 5000000000000002
+      var o = {length: 5000000000000000};
+      var o = {length: 5000000000000000};
+      Array.prototype.push.call(o, 'foo') === 5000000000000001 &&
+          Array.prototype.push.call(o, 'bar') === 5000000000000002 &&
+          o[5000000000000000] === 'foo' && o[5000000000000001] === 'bar' &&
+          o.length === 5000000000000002
     `,
     expected: true
   },
   {
     name: 'Array.prototype.reverse odd-length',
     src: `
-        var a = [1, 2, 3];
-        a.reverse() === a && a.length === 3 && String(a);
+      var a = [1, 2, 3];
+      a.reverse() === a && a.length === 3 && String(a);
     `,
     expected: '3,2,1'
   },
   {
     name: 'Array.prototype.reverse even-length',
     src: `
-        var a = [1, 2, , 4];
-        a.reverse() === a && a.length === 4 && String(a);
+      var a = [1, 2, , 4];
+      a.reverse() === a && a.length === 4 && String(a);
     `,
     expected: '4,,2,1'
   },
   {
     name: 'Array.prototype.reverse empty',
     src: `
-        var a = [];
-        a.reverse() === a && a.length;
+      var a = [];
+      a.reverse() === a && a.length;
     `,
     expected: 0
   },
   {
     name: 'Array.prototype.reverse.call(odd-length array-like)',
     src: `
-        var o = {0: 1, 1: 2, 2: 3, length: 3};
-        Array.prototype.reverse.call(o) === o && o.length === 3 &&
-            Array.prototype.slice.apply(o).toString();
+      var o = {0: 1, 1: 2, 2: 3, length: 3};
+      Array.prototype.reverse.call(o) === o && o.length === 3 &&
+          Array.prototype.slice.apply(o).toString();
     `,
     expected: '3,2,1'
   },
   {
     name: 'Array.prototype.reverse.call(even-length array-like)',
     src: `
-        var o = {0: 1, 1: 2, 3: 4, length: 4};
-        Array.prototype.reverse.call(o) === o && o.length === 4 &&
-            Array.prototype.slice.apply(o).toString();
+      var o = {0: 1, 1: 2, 3: 4, length: 4};
+      Array.prototype.reverse.call(o) === o && o.length === 4 &&
+          Array.prototype.slice.apply(o).toString();
     `,
     expected: '4,,2,1'
   },
   {
     name: 'Array.prototype.reverse.call(empty array-like)',
     src: `
-        var o = {length: 0};
-        Array.prototype.reverse.call(o) === o && o.length;
+      var o = {length: 0};
+      Array.prototype.reverse.call(o) === o && o.length;
     `,
     expected: 0
   },
   {
     name: 'Array.prototype.shift',
     src: `
-        var a = ['foo', 'bar', 'baz'];
-        var r = a.shift();
-        a.length === 2 && a[0] === 'bar' && a[1] === 'baz' && r;
+      var a = ['foo', 'bar', 'baz'];
+      var r = a.shift();
+      a.length === 2 && a[0] === 'bar' && a[1] === 'baz' && r;
     `,
     expected: 'foo'
   },
   {
     name: 'Array.prototype.shift empty array',
     src: `
-        var a = [];
-        var r = a.shift();
-        a.length === 0 && r;
+      var a = [];
+      var r = a.shift();
+      a.length === 0 && r;
     `,
     expected: undefined
   },
   {
     name: 'Array.prototype.shift.apply(array-like)',
     src: `
-        var o = {0: 'foo', 1: 'bar', 2: 'baz', length: 3};
-        var r = Array.prototype.shift.apply(o);
-        o.length === 2 && o[0] === 'bar' && o[1] === 'baz' && r;
+      var o = {0: 'foo', 1: 'bar', 2: 'baz', length: 3};
+      var r = Array.prototype.shift.apply(o);
+      o.length === 2 && o[0] === 'bar' && o[1] === 'baz' && r;
     `,
     expected: 'foo'
   },
   {
     name: 'Array.prototype.shift.apply(empty array-like)',
     src: `
-        var o = {length: 0};
-        var r = Array.prototype.shift.apply(o);
-        o.length === 0 && r;
+      var o = {length: 0};
+      var r = Array.prototype.shift.apply(o);
+      o.length === 0 && r;
     `,
     expected: undefined
   },
   {
     name: 'Array.prototype.shift.apply(huge array-like)',
     src: `
-        var o = {5000000000000000: 'foo',
-                 5000000000000001: 'quux',
-                 length: 5000000000000002};
-        var r = Array.prototype.shift.apply(o);
-        o.length === 5000000000000001 && o[5000000000000000] === 'quux' && r;
+      var o = {5000000000000000: 'foo',
+               5000000000000001: 'quux',
+               length: 5000000000000002};
+      var r = Array.prototype.shift.apply(o);
+      o.length === 5000000000000001 && o[5000000000000000] === 'quux' && r;
     `,
     // SKIP until more efficient shift implementation available.
     /* expected: 'foo' */
@@ -2276,62 +2277,62 @@ module.exports = [
   {
     name: 'Array.prototype.slice()',
     src: `
-        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
-        var s = a.slice();
-        a.length === 6 && s.length === 6 && String(s);
+      var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+      var s = a.slice();
+      a.length === 6 && s.length === 6 && String(s);
     `,
     expected: 'foo,bar,baz,,quux,quuux'
   },
   {
     name: 'Array.prototype.slice(-)',
     src: `
-        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
-        var s = a.slice(-2);
-        a.length === 6 && s.length === 2 && String(s);
+      var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+      var s = a.slice(-2);
+      a.length === 6 && s.length === 2 && String(s);
     `,
     expected: 'quux,quuux'
   },
   {
     name: 'Array.prototype.slice(+, +)',
     src: `
-        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
-        var s = a.slice(1, 4);
-        a.length === 6 && s.length === 3 && !('2' in s) && String(s);
+      var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+      var s = a.slice(1, 4);
+      a.length === 6 && s.length === 3 && !('2' in s) && String(s);
     `,
     expected: 'bar,baz,'
   },
   {
     name: 'Array.prototype.slice(+, -)',
     src: `
-        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
-        var s = a.slice(1, -2);
-        a.length === 6 && s.length === 3 && !('2' in s) && String(s);
+      var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+      var s = a.slice(1, -2);
+      a.length === 6 && s.length === 3 && !('2' in s) && String(s);
     `,
     expected: 'bar,baz,'
   },
   {
     name: 'Array.prototype.slice.call(array-like, -, +)',
     src: `
-        var o = {
-          0: 'foo', 1: 'bar', 2: 'baz', 4: 'quux', 5: 'quuux', length: 6
-        };
-        var s = Array.prototype.slice.call(o, -5, 4);
-        !Array.isArray(o) && o.length === 6 &&
-            Array.isArray(s) && s.length === 3 && !('2' in s) && String(s);
+      var o = {
+        0: 'foo', 1: 'bar', 2: 'baz', 4: 'quux', 5: 'quuux', length: 6
+      };
+      var s = Array.prototype.slice.call(o, -5, 4);
+      !Array.isArray(o) && o.length === 6 &&
+          Array.isArray(s) && s.length === 3 && !('2' in s) && String(s);
     `,
     expected: 'bar,baz,'
   },
   {
     name: 'Array.prototype.slice.call(huge array-like, -, -)',
     src: `
-        var o = {
-          5000000000000000: 'foo', 5000000000000001: 'bar',
-          5000000000000002: 'baz', 5000000000000004: 'quux',
-          5000000000000005: 'quuux', length: 5000000000000006
-        };
-        var s = Array.prototype.slice.call(o, -5, -2);
-        !Array.isArray(o) && o.length === 5000000000000006 &&
-            Array.isArray(s) && s.length === 3 && !('2' in s) && String(s);
+      var o = {
+        5000000000000000: 'foo', 5000000000000001: 'bar',
+        5000000000000002: 'baz', 5000000000000004: 'quux',
+        5000000000000005: 'quuux', length: 5000000000000006
+      };
+      var s = Array.prototype.slice.call(o, -5, -2);
+      !Array.isArray(o) && o.length === 5000000000000006 &&
+          Array.isArray(s) && s.length === 3 && !('2' in s) && String(s);
     `,
     expected: 'bar,baz,'
   },
@@ -2343,97 +2344,100 @@ module.exports = [
   {
     name: 'Array.prototype.sort() compaction',
     src: `
-    ['z', undefined, 10, , 'aa', null, 'a', 5, NaN, , 1].sort()
-        .map(String).join();
+      ['z', undefined, 10, , 'aa', null, 'a', 5, NaN, , 1].sort()
+          .map(String).join();
     `,
     expected: '1,10,5,NaN,a,aa,null,z,undefined,,'
   },
   {
-    name: 'Array.prototype.sort(comparefn)',
-    src: `[99, 9, 10, 11, 1, 0, 5].sort(function(a, b) {return a - b;}).join();`,
+    name: 'Array.prototype.sort(/* comparefn */)',
+    src: `
+      [99, 9, 10, 11, 1, 0, 5]
+          .sort(function(a, b) {return a - b;}).join();
+    `,
     expected: '0,1,5,9,10,11,99'
   },
   {
-    name: 'Array.prototype.sort(comparefn) compaction',
+    name: 'Array.prototype.sort(/* comparefn */) compaction',
     src: `
-    ['z', undefined, 10, , 'aa', null, 'a', 5, NaN, , 1].sort(
-        function(a, b) {
-          // Try to put undefineds first - should not succeed.
-          if (a === undefined) return b === undefined ? 0 : -1;
-          if (b === undefined) return 1;
-          // Reverse order of ususal sort.
-          a = String(a);
-          b = String(b);
-          if (a > b) return -1;
-          if (b > a) return 1;
-          return 0;
-        }).map(String).join();
+      ['z', undefined, 10, , 'aa', null, 'a', 5, NaN, , 1]
+          .sort(function(a, b) {
+            // Try to put undefineds first - should not succeed.
+            if (a === undefined) return b === undefined ? 0 : -1;
+            if (b === undefined) return 1;
+            // Reverse order of ususal sort.
+            a = String(a);
+            b = String(b);
+            if (a > b) return -1;
+            if (b > a) return 1;
+            return 0;
+          }).map(String).join();
     `,
     expected: 'z,null,aa,a,NaN,5,10,1,undefined,,'
   },
   {
     name: 'Array.prototype.splice()',
     src: `
-        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
-        var s = a.splice();
-        a.length === 6 && s.length === 0 && String(a) + ':' + String(s);
+      var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+      var s = a.splice();
+      a.length === 6 && s.length === 0 && String(a) + ':' + String(s);
     `,
     expected: 'foo,bar,baz,,quux,quuux:'
   },
   {
     name: 'Array.prototype.splice(-)',
     src: `
-        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
-        var s = a.splice(-2);
-        a.length === 4 && s.length === 2 && String(a) + ':' + String(s);
+      var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+      var s = a.splice(-2);
+      a.length === 4 && s.length === 2 && String(a) + ':' + String(s);
     `,
     expected: 'foo,bar,baz,:quux,quuux'
   },
   {
     name: 'Array.prototype.splice(+, +, ...)',
     src: `
-        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
-        var s = a.splice(1, 3, 'bletch');
-        a.length === 4 && s.length === 3 && String(a) + ':' + String(s);
+      var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+      var s = a.splice(1, 3, 'bletch');
+      a.length === 4 && s.length === 3 && String(a) + ':' + String(s);
     `,
     expected: 'foo,bletch,quux,quuux:bar,baz,'
   },
   {
     name: 'Array.prototype.splice.call(array-like, 0, large, ...)',
     src: `
-        var o = {
-          0: 'foo', 1: 'bar', 2: 'baz', 4: 'quux', 5: 'quuux', length: 6
-        };
-        var s = Array.prototype.splice.call(o, 0, 100, 'bletch');
-        !Array.isArray(o) && o.length === 1 && Object.keys(o).length === 2 &&
-        o[0] === 'bletch' &&
-        Array.isArray(s) && s.length === 6 && !('3' in s) && String(s);
+      var o = {
+        0: 'foo', 1: 'bar', 2: 'baz', 4: 'quux', 5: 'quuux', length: 6
+      };
+      var s = Array.prototype.splice.call(o, 0, 100, 'bletch');
+      !Array.isArray(o) && o.length === 1 && Object.keys(o).length === 2 &&
+      o[0] === 'bletch' &&
+      Array.isArray(s) && s.length === 6 && !('3' in s) && String(s);
     `,
     expected: 'foo,bar,baz,,quux,quuux'
   },
   {
     name: 'Array.prototype.splice.call(huge array-like, -, -, many...)',
     src: `
-        var o = {
-          5000000000000000: 'foo', 5000000000000001: 'bar',
-          5000000000000002: 'baz', 5000000000000004: 'quux',
-          5000000000000005: 'quuux', length: 5000000000000006
-        };
-        var s = Array.prototype.splice.call(o, -2, -999, 'bletch', 'qux');
-        !Array.isArray(o) && o.length === 5000000000000008 &&
-            o[5000000000000004] === 'bletch' && o[5000000000000005] === 'qux' &&
-            o[5000000000000006] === 'quux' && o[5000000000000007] === 'quuux' &&
-            Array.isArray(s) && s.length === 0;
+      var o = {
+        5000000000000000: 'foo', 5000000000000001: 'bar',
+        5000000000000002: 'baz', 5000000000000004: 'quux',
+        5000000000000005: 'quuux', length: 5000000000000006
+      };
+      var s = Array.prototype.splice.call(o, -2, -999, 'bletch', 'qux');
+      !Array.isArray(o) && o.length === 5000000000000008 &&
+          o[5000000000000004] === 'bletch' && o[5000000000000005] === 'qux' &&
+          o[5000000000000006] === 'quux' && o[5000000000000007] === 'quuux' &&
+          Array.isArray(s) && s.length === 0;
     `,
     expected: true
   },
   {
     name: 'Array.prototype.toString cycle detection',
     src: `
-    var a = [1, , 3];
-    a[1] = a;
-    a.toString();
-    "Didn't crash!";
+      var a = [1, , 3];
+      a[1] = a;
+      a.toString();
+      "Didn't crash!";
     `,
     expected: 'Didn\'t crash!'
   },
@@ -2450,31 +2454,31 @@ module.exports = [
   {
     name: 'Array.prototype.unshift',
     src: `
-        var a = [];
-        a.unshift('foo') === 1 && a.unshift('bar') === 2 &&
-            a.length === 2 && a[0] === 'bar' && a[1] === 'foo';
+      var a = [];
+      a.unshift('foo') === 1 && a.unshift('bar') === 2 &&
+          a.length === 2 && a[0] === 'bar' && a[1] === 'foo';
     `,
     expected: true
   },
   {
     name: 'Array.prototype.unshift.call(array-like, ...)',
     src: `
-        var o = {length: 0};
-        Array.prototype.unshift.call(o, 'foo') === 1 &&
-            Array.prototype.unshift.call(o, 'bar') === 2 &&
-            o.length === 2 && o[0] === 'bar' && o[1] === 'foo';
+      var o = {length: 0};
+      Array.prototype.unshift.call(o, 'foo') === 1 &&
+          Array.prototype.unshift.call(o, 'bar') === 2 &&
+          o.length === 2 && o[0] === 'bar' && o[1] === 'foo';
     `,
     expected: true
   },
   {
     name: 'Array.prototype.unshift.call(huge array-like, ...)',
     src: `
-        var o = {length: 5000000000000000};
-        var o = {length: 5000000000000000};
-        Array.prototype.unshift.call(o, 'foo') === 5000000000000001 &&
-            Array.prototype.push.call(o, 'bar') === 5000000000000002 &&
-            o[5000000000000000] === 'bar' && o[5000000000000001] === 'foo' &&
-            o.length === 5000000000000002
+      var o = {length: 5000000000000000};
+      var o = {length: 5000000000000000};
+      Array.prototype.unshift.call(o, 'foo') === 5000000000000001 &&
+          Array.prototype.push.call(o, 'bar') === 5000000000000002 &&
+          o[5000000000000000] === 'bar' && o[5000000000000001] === 'foo' &&
+          o.length === 5000000000000002
     `,
     // SKIP until more efficient unshift implementation available.
     /* expected: true */
@@ -2484,27 +2488,27 @@ module.exports = [
   {
     name: 'Boolean',
     src: `
-    var tests = [
-      [undefined, false],
-      [null, false],
-      [false, false],
-      [true, true],
-      [NaN, false],
-      [0, false],
-      [1, true],
-      ['', false],
-      ['foo', true],
-      [{}, true],
-      [[], true],
-      [function() {}, true],
-    ];
-    var ok = 0;
-    for (var i = 0; i < tests.length; i++) {
-      if (Boolean(tests[i][0]) === tests[i][1]) {
-        ok++;
+      var tests = [
+        [undefined, false],
+        [null, false],
+        [false, false],
+        [true, true],
+        [NaN, false],
+        [0, false],
+        [1, true],
+        ['', false],
+        ['foo', true],
+        [{}, true],
+        [[], true],
+        [function() {}, true],
+      ];
+      var ok = 0;
+      for (var i = 0; i < tests.length; i++) {
+        if (Boolean(tests[i][0]) === tests[i][1]) {
+          ok++;
+        }
       }
-    }
-    (ok === tests.length) ? 'pass' : 'fail';
+      (ok === tests.length) ? 'pass' : 'fail';
     `,
     expected: 'pass'
   },
@@ -2523,11 +2527,11 @@ module.exports = [
   {
     name: 'Boolean.prototype.toString.call non-Boolean object',
     src: `
-    try {
-      Boolean.prototype.toString.call({});
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Boolean.prototype.toString.call({});
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -2546,11 +2550,11 @@ module.exports = [
   {
     name: 'Boolean.prototype.valueOf.call non-Boolean object',
     src: `
-    try {
-      Boolean.prototype.valueOf.call({});
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Boolean.prototype.valueOf.call({});
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -2560,35 +2564,35 @@ module.exports = [
   {
     name: 'Number',
     src: `
-    var tests = [
-      [undefined, NaN],
-      [null, 0],
-      [true, 1],
-      [false, 0],
-      ['42', 42],
-      ['', 0],
-      [{}, NaN],
-      [[], 0],
-      [[42], 42],
-      [[1,2,3], NaN],
-      [function() {}, NaN],
-    ];
-    var ok = 0;
-    for (var i = 0; i < tests.length; i++) {
-      if (Object.is(Number(tests[i][0]), tests[i][1])) {
-        ok++;
+      var tests = [
+        [undefined, NaN],
+        [null, 0],
+        [true, 1],
+        [false, 0],
+        ['42', 42],
+        ['', 0],
+        [{}, NaN],
+        [[], 0],
+        [[42], 42],
+        [[1,2,3], NaN],
+        [function() {}, NaN],
+      ];
+      var ok = 0;
+      for (var i = 0; i < tests.length; i++) {
+        if (Object.is(Number(tests[i][0]), tests[i][1])) {
+          ok++;
+        }
       }
-    }
-    (ok === tests.length) ? 'pass' : 'fail';
+      (ok === tests.length) ? 'pass' : 'fail';
     `,
     expected: 'pass'
   },
   {
     name: 'Number.MAX_SAFE_INTEGER',
     src: `
-    Number.MAX_SAFE_INTEGER + 1 === Math.pow(2, 53) &&
-        Number.isSafeInteger(Number.MAX_SAFE_INTEGER) &&
-        !Number.isSafeInteger(Number.MAX_SAFE_INTEGER + 1);
+      Number.MAX_SAFE_INTEGER + 1 === Math.pow(2, 53) &&
+          Number.isSafeInteger(Number.MAX_SAFE_INTEGER) &&
+          !Number.isSafeInteger(Number.MAX_SAFE_INTEGER + 1);
     `,
     expected: true
   },
@@ -2603,11 +2607,11 @@ module.exports = [
   {
     name: 'Number.prototype.toString.call non-Number object',
     src: `
-    try {
-      Number.prototype.toString.call({});
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Number.prototype.toString.call({});
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -2622,11 +2626,11 @@ module.exports = [
   {
     name: 'Number.prototype.valueOf.call non-Number object',
     src: `
-    try {
-      Number.prototype.valueOf.call({});
-    } catch (e) {
-      e.name;
-    }
+      try {
+        Number.prototype.valueOf.call({});
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -2636,90 +2640,90 @@ module.exports = [
   {
     name: 'String',
     src: `
-    var tests = [
-      [undefined, 'undefined'],
-      [null, 'null'],
-      [true, 'true'],
-      [false, 'false'],
-      [0, '0'],
-      [-0, '0'],
-      [Infinity, 'Infinity'],
-      [-Infinity, '-Infinity'],
-      [NaN, 'NaN'],
-      [{}, '[object Object]'],
-      [[1, 2, 3,,5], '1,2,3,,5'],
-    ];
-    var ok = 0;
-    for (var i = 0; i < tests.length; i++) {
-      if (String(tests[i][0]) === tests[i][1]) {
-        ok++;
+      var tests = [
+        [undefined, 'undefined'],
+        [null, 'null'],
+        [true, 'true'],
+        [false, 'false'],
+        [0, '0'],
+        [-0, '0'],
+        [Infinity, 'Infinity'],
+        [-Infinity, '-Infinity'],
+        [NaN, 'NaN'],
+        [{}, '[object Object]'],
+        [[1, 2, 3,,5], '1,2,3,,5'],
+      ];
+      var ok = 0;
+      for (var i = 0; i < tests.length; i++) {
+        if (String(tests[i][0]) === tests[i][1]) {
+          ok++;
+        }
       }
-    }
-    (ok === tests.length) ? 'pass' : 'fail';
+      (ok === tests.length) ? 'pass' : 'fail';
     `,
     expected: 'pass'
   },
   {
     name: 'String calls valueOf',
     src: `
-        var o = Object.create(null);
-        o.valueOf = function() {return 'OK';};
-        String(o);
+      var o = Object.create(null);
+      o.valueOf = function() {return 'OK';};
+      String(o);
     `,
     expected: 'OK'
   },
   {
     name: 'String calling valueOf returns string',
     src: `
-        var o = Object.create(null);
-        o.valueOf = function() {return 42;};
-        String(o);
+      var o = Object.create(null);
+      o.valueOf = function() {return 42;};
+      String(o);
     `,
     expected: '42'
   },
   {
     name: 'String calling valueOf throws',
     src: `
-        var o = Object.create(null);
-        o.valueOf = function() {return {};};
-        try {
-          String(o);
-        } catch (e) {
-          e.name;
-        }
+      var o = Object.create(null);
+      o.valueOf = function() {return {};};
+      try {
+        String(o);
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'String calls toString',
     src: `
-        var o = Object.create(null);
-        o.valueOf = function() {return 'Whoops: called valueOf';};
-        o.toString = function() {return 'OK';};
-        String(o);
+      var o = Object.create(null);
+      o.valueOf = function() {return 'Whoops: called valueOf';};
+      o.toString = function() {return 'OK';};
+      String(o);
     `,
     expected: 'OK'
   },
   {
     name: 'String calling toString returns string',
     src: `
-        var o = Object.create(null);
-        o.valueOf = function() {return 42;};
-        String(o);
+      var o = Object.create(null);
+      o.valueOf = function() {return 42;};
+      String(o);
     `,
     expected: '42'
   },
   {
     name: 'String calling toString throws',
     src: `
-        var o = Object.create(null);
-        o.valueOf = function() {return {};};
-        o.toString = function() {return {};};
-        try {
-          String(o);
-        } catch (e) {
-          e.name;
-        }
+      var o = Object.create(null);
+      o.valueOf = function() {return {};};
+      o.toString = function() {return {};};
+      try {
+        String(o);
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -2740,18 +2744,18 @@ module.exports = [
   {
     name: 'String.prototype.replace(string, function)',
     src: `
-    'xxxx'.replace('xx', function() {
-         return '[' + Array.prototype.join.apply(arguments) + ']';
-    });
+      'xxxx'.replace('xx', function() {
+           return '[' + Array.prototype.join.apply(arguments) + ']';
+      });
     `,
     expected: '[xx,0,xxxx]xx'
   },
   {
     name: 'String.prototype.replace(regexp, function)',
     src: `
-    'xxxx'.replace(/(X)\\1/ig, function() {
-         return '[' + Array.prototype.join.apply(arguments) + ']';
-    });
+      'xxxx'.replace(/(X)\\1/ig, function() {
+           return '[' + Array.prototype.join.apply(arguments) + ']';
+      });
     `,
     expected: '[xx,x,0,xxxx][xx,x,2,xxxx]'
   },
@@ -2787,11 +2791,11 @@ module.exports = [
   {
     name: 'String.prototype.toString.call non-String object',
     src: `
-    try {
-      String.prototype.toString.call({});
-    } catch (e) {
-      e.name;
-    }
+      try {
+        String.prototype.toString.call({});
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -2807,11 +2811,11 @@ module.exports = [
   {
     name: 'String.prototype.valueOf.call non-String object',
     src: `
-    try {
-      String.prototype.valueOf.call({});
-    } catch (e) {
-      e.name;
-    }
+      try {
+        String.prototype.valueOf.call({});
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -2820,11 +2824,11 @@ module.exports = [
   {
     name: 'RegExp.prototype.test.apply(non-regexp) throws',
     src: `
-    try {
-      /foo/.test.apply({}, ['foo']);
-    } catch (e) {
-      e.name;
-    }
+      try {
+        /foo/.test.apply({}, ['foo']);
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -2833,32 +2837,32 @@ module.exports = [
   {
     name: 'new Error has .stack',
     src: `
-    // Use eval to make parsing .stack easier.
-    var e = eval('new Error;');
-    var lines = e.stack.split('\\n');
-    lines[0].trim();
+      // Use eval to make parsing .stack easier.
+      var e = eval('new Error;');
+      var lines = e.stack.split('\\n');
+      lines[0].trim();
     `,
     expected: 'at "new Error;" 1:1'
   },
   {
     name: 'thrown Error has .stack',
     src: `
-    try {
-      (function buggy() {1 instanceof 2;})();
-    } catch (e) {
-      var lines = e.stack.split('\\n');
-    }
-    lines[0].trim();
+      try {
+        (function buggy() {1 instanceof 2;})();
+      } catch (e) {
+        var lines = e.stack.split('\\n');
+      }
+      lines[0].trim();
     `,
     expected: 'at buggy 1:19'
   },
   {
     name: 'Error .stack correctly reports anonymous function',
     src: `
-    // Use eval to make parsing .stack easier.
-    var e = eval('(function() {return new Error;})()');
-    var lines = e.stack.split('\\n');
-    lines[0].trim();
+      // Use eval to make parsing .stack easier.
+      var e = eval('(function() {return new Error;})()');
+      var lines = e.stack.split('\\n');
+      lines[0].trim();
     `,
     expected: 'at anonymous function 1:20'
   },
@@ -2866,44 +2870,44 @@ module.exports = [
   {
     name: 'Error .stack correctly blames MemberExpression',
     src: `
-    function foo() {
-      switch (1) {
-        case 1:
-          return undefined.hasNoProperties;
+      function foo() {
+        switch (1) {
+          case 1:
+            return undefined.hasNoProperties;
+        }
       }
-    }
-    try {
-      foo();
-    } catch (e) {
-      var lines = e.stack.split('\\n');
-    }
-    lines[0].trim();
+      try {
+        foo();
+      } catch (e) {
+        var lines = e.stack.split('\\n');
+      }
+      lines[0].trim();
     `,
-    expected: 'at foo 4:18'
+    expected: 'at foo 4:20'
   },
   {
     name: 'Error .stack correctly blames Identifier',
     src: `
-    function foo() {
-      return undefinedVariable;
-    }
-    try {
-      foo();
-    } catch (e) {
-      var lines = e.stack.split('\\n');
-    }
-    lines[0].trim();
+      function foo() {
+        return undefinedVariable;
+      }
+      try {
+        foo();
+      } catch (e) {
+        var lines = e.stack.split('\\n');
+      }
+      lines[0].trim();
     `,
-    expected: 'at foo 2:14'
+    expected: 'at foo 2:16'
   },
   /////////////////////////////////////////////////////////////////////////////
   // JSON
   {
     name: 'JSON.stringify basic',
     src: `
-    JSON.stringify({
-        string: 'foo', number: 42, true: true, false: false, null: null,
-        object: {obj: {}, arr: []}, array: [{}, []] });
+      JSON.stringify({
+          string: 'foo', number: 42, true: true, false: false, null: null,
+          object: {obj: {}, arr: []}, array: [{}, []] });
     `,
     expected: '{"string":"foo","number":42,"true":true,"false":false,' +
         '"null":null,"object":{"obj":{},"arr":[]},"array":[{},[]]}'
@@ -2923,39 +2927,39 @@ module.exports = [
   {
     name: 'JSON.stringify filter',
     src: `
-    JSON.stringify({
-        string: 'foo', number: 42, true: true, false: false, null: null,
-        object: {obj: {}, arr: []}, array: [{}, []] },
-        ['string', 'number']);
+      JSON.stringify({
+          string: 'foo', number: 42, true: true, false: false, null: null,
+          object: {obj: {}, arr: []}, array: [{}, []] },
+          ['string', 'number']);
     `,
     expected: '{"string":"foo","number":42}'
   },
   {
     name: 'JSON.stringify pretty number',
     src: `
-    JSON.stringify({
-        string: 'foo', number: 42, true: true, false: false, null: null,
-        object: {obj: {}, arr: []}, array: [{}, []] },
-        ['string', 'number'], 2);
+      JSON.stringify({
+          string: 'foo', number: 42, true: true, false: false, null: null,
+          object: {obj: {}, arr: []}, array: [{}, []] },
+          ['string', 'number'], 2);
     `,
     expected: '{\n  "string": "foo",\n  "number": 42\n}'
   },
   {
     name: 'JSON.stringify pretty string',
     src: `
-    JSON.stringify({
-        string: 'foo', number: 42, true: true, false: false, null: null,
-        object: {obj: {}, arr: []}, array: [{}, []] },
-        ['string', 'number'], '--');
+      JSON.stringify({
+          string: 'foo', number: 42, true: true, false: false, null: null,
+          object: {obj: {}, arr: []}, array: [{}, []] },
+          ['string', 'number'], '--');
     `,
     expected: '{\n--"string": "foo",\n--"number": 42\n}'
   },
   {
     name: 'JSON.stringify nonenumerable',
     src: `
-    var obj = {e: 'enumerable', ne: 'nonenumerable'};
-    Object.defineProperty(obj, 'ne', {enumerable: false});
-    JSON.stringify(obj);
+      var obj = {e: 'enumerable', ne: 'nonenumerable'};
+      Object.defineProperty(obj, 'ne', {enumerable: false});
+      JSON.stringify(obj);
     `,
     expected: '{"e":"enumerable"}'
   },
@@ -2967,13 +2971,13 @@ module.exports = [
   {
     name: 'JSON.stringify circular',
     src: `
-    var obj = {};
-    obj.circular = obj;
-    try {
-      JSON.stringify(obj);
-    } catch (e) {
-      e.name;
-    }
+      var obj = {};
+      obj.circular = obj;
+      try {
+        JSON.stringify(obj);
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
@@ -2982,11 +2986,11 @@ module.exports = [
   {
     name: 'decodeURI throws',
     src: `
-    try {
-      decodeURI('%xy');
-    } catch (e) {
-      e.name;
-    }
+      try {
+        decodeURI('%xy');
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'URIError'
   },
@@ -2995,67 +2999,67 @@ module.exports = [
   {
     name: 'WeakMap',
     src: `
-    var w = new WeakMap;
-    var p = {};
-    var o = Object.create(p);
-    var fails = 0;
-    !w.has(p) || fails++;
-    !w.delete(p) || fails++;
-    w.set(o, 'o') === w || fails++;
-    w.get(o) === 'o' || fails++;
-    w.get(p) === undefined || fails++;
-    w.has(o) || fails++;
-    w.delete(o) || fails++;
-    !w.has(o) || fails++;
-    fails;
+      var w = new WeakMap;
+      var p = {};
+      var o = Object.create(p);
+      var fails = 0;
+      !w.has(p) || fails++;
+      !w.delete(p) || fails++;
+      w.set(o, 'o') === w || fails++;
+      w.get(o) === 'o' || fails++;
+      w.get(p) === undefined || fails++;
+      w.has(o) || fails++;
+      w.delete(o) || fails++;
+      !w.has(o) || fails++;
+      fails;
     `,
     expected: 0
   },
   {
     name: 'WeakMap.prototype methods reject non-WeakMap this',
     src: `
-    var w = new WeakMap;
-    var fails = 0;
-    function expectError(method, thisVal, args) {
-      try {
-        w[method].apply(thisVal, args);
-        fails++;
-      } catch (e) {
-        if (e.name !== 'TypeError') fails++;
+      var w = new WeakMap;
+      var fails = 0;
+      function expectError(method, thisVal, args) {
+        try {
+          w[method].apply(thisVal, args);
+          fails++;
+        } catch (e) {
+          if (e.name !== 'TypeError') fails++;
+        }
       }
-    }
-    var methods = ['delete', 'get', 'has', 'set'];
-    var values = [null, undefined, true, false, 0, 42, '', 'hi'];
-    for (var i = 0; i < methods.length; i++) {
-      var method = methods[i];
-      for (var j = 0; j < values.length; j++) {
-        var value = values[j];
-        expectError(method, value, [{}]);  // Can't call method on non-WeakMap.
-        expectError(method, w, [value]);  // Can't store non-object in WeakMap.
+      var methods = ['delete', 'get', 'has', 'set'];
+      var values = [null, undefined, true, false, 0, 42, '', 'hi'];
+      for (var i = 0; i < methods.length; i++) {
+        var method = methods[i];
+        for (var j = 0; j < values.length; j++) {
+          var value = values[j];
+          expectError(method, value, [{}]); // Can't call method on non-WeakMap.
+          expectError(method, w, [value]); // Can't store non-object in WeakMap.
+        }
+        // WeakMap.prototype is an ordinary object, not a WeakMap.
+        expectError(method, WeakMap.prototpye, [{}]);
       }
-      // WeakMap.prototype is an ordinary object, not a WeakMap.
-      expectError(method, WeakMap.prototpye, [{}]);
-    }
-    fails;
+      fails;
     `,
     expected: 0
   },
   {
     name: 'WeakMap',
     src: `
-    var w = new WeakMap;
-    var p = {};
-    var o = Object.create(p);
-    var fails = 0;
-    !w.has(p) || fails++;
-    !w.delete(p) || fails++;
-    w.set(o, 'o') === w || fails++;
-    w.get(o) === 'o' || fails++;
-    w.get(p) === undefined || fails++;
-    w.has(o) || fails++;
-    w.delete(o) || fails++;
-    !w.has(o) || fails++;
-    fails;
+      var w = new WeakMap;
+      var p = {};
+      var o = Object.create(p);
+      var fails = 0;
+      !w.has(p) || fails++;
+      !w.delete(p) || fails++;
+      w.set(o, 'o') === w || fails++;
+      w.get(o) === 'o' || fails++;
+      w.get(p) === undefined || fails++;
+      w.has(o) || fails++;
+      w.delete(o) || fails++;
+      !w.has(o) || fails++;
+      fails;
     `,
     expected: 0
   },
@@ -3066,11 +3070,11 @@ module.exports = [
   {
     name: 'Thread.callers() ownership',
     src: `
-    var owner = {};
-    setPerms(owner);
-    var callers = Thread.callers();
-    Object.getOwnerOf(callers) === owner &&
-        Object.getOwnerOf(callers[0]) === owner;
+      var owner = {};
+      setPerms(owner);
+      var callers = Thread.callers();
+      Object.getOwnerOf(callers) === owner &&
+          Object.getOwnerOf(callers[0]) === owner;
     `,
     expected: true
   },
@@ -3087,21 +3091,21 @@ module.exports = [
   {
     name: 'Thread.callers()[/* last */].program',
     src: `
-    var callers = Thread.callers();
-    typeof callers[callers.length - 1].program;
+      var callers = Thread.callers();
+      typeof callers[callers.length - 1].program;
     `,
     expected: 'string'
   },
   {
     name: 'Thread.callers()[0].callerPerms',
     src: `
-    CC.root.name = 'root';
-    var user = {name: 'user'};
-    function f() {
-      return Thread.callers()[0].callerPerms.name;
-    }
-    setPerms(user);
-    f();
+      CC.root.name = 'root';
+      var user = {name: 'user'};
+      function f() {
+        return Thread.callers()[0].callerPerms.name;
+      }
+      setPerms(user);
+      f();
     `,
     expected: 'user'
   },
@@ -3116,16 +3120,16 @@ module.exports = [
   {
     name: 'Thread.prototype.setTimeLimit()',
     src: `
-    Thread.current().setTimeLimit(1000);
-    Thread.current().getTimeLimit();
+      Thread.current().setTimeLimit(1000);
+      Thread.current().getTimeLimit();
     `,
     expected: 1000
   },
   {
     name: 'Thread.prototype.setTimeLimit(...)',
     src: `
-    Thread.current().setTimeLimit(1000);
-    Thread.current().getTimeLimit();
+      Thread.current().setTimeLimit(1000);
+      Thread.current().getTimeLimit();
     `,
     expected: 1000
   },
@@ -3133,17 +3137,17 @@ module.exports = [
   {
     name: 'Thread.prototype.setTimeLimit(/* invalid value */) throws',
     src: `
-    Thread.current().setTimeLimit(1000);
-    var invalid = [0, 1001, NaN, 'foo', true, {}];
-    var failures = [];
-    for (var i = 0; i < invalid.length; i++) {
-      try {
-        Thread.current().setTimeLimit(invalid[i]);
-        failures.push(invalid[i]);
-      } catch (e) {
+      Thread.current().setTimeLimit(1000);
+      var invalid = [0, 1001, NaN, 'foo', true, {}];
+      var failures = [];
+      for (var i = 0; i < invalid.length; i++) {
+        try {
+          Thread.current().setTimeLimit(invalid[i]);
+          failures.push(invalid[i]);
+        } catch (e) {
+        }
       }
-    }
-    (failures.length === 0) ? 'OK' : String(failures);
+      (failures.length === 0) ? 'OK' : String(failures);
     `,
     expected: 'OK'
   },
@@ -3157,38 +3161,38 @@ module.exports = [
   {
     name: 'setPerms',
     src: `
-    CC.root.name = 'Root';
-    var bob = {};
-    bob.name = 'Bob';
-    var r = '';
-    r += perms().name;
-    (function() {
-      setPerms(bob);
+      CC.root.name = 'Root';
+      var bob = {};
+      bob.name = 'Bob';
+      var r = '';
       r += perms().name;
-      // Perms revert at end of scope.
-    })();
-    r += perms().name;
-    r;`,
-    expected: 'RootBobRoot'
+      (function() {
+        setPerms(bob);
+        r += perms().name;
+        // Perms revert at end of scope.
+      })();
+      r += perms().name;
+      r;`,
+      expected: 'RootBobRoot'
   },
   {
-    name: 'getOwnerOf',
-    src: `
-    var bob = {};
-    var roots = {};
-    setPerms(bob);
-    var bobs = new Object;
-    Object.getOwnerOf(Object) === CC.root &&
-    Object.getOwnerOf(roots) === CC.root &&
-    Object.getOwnerOf(bobs) === bob`,
-    expected: true
+      name: 'getOwnerOf',
+      src: `
+      var bob = {};
+      var roots = {};
+      setPerms(bob);
+      var bobs = new Object;
+      Object.getOwnerOf(Object) === CC.root &&
+      Object.getOwnerOf(roots) === CC.root &&
+      Object.getOwnerOf(bobs) === bob`,
+      expected: true
   },
   {
-    name: 'setOwnerOf',
-    src: `
-    var bob = {};
-    var obj = {};
-    Object.setOwnerOf(obj, bob) === obj && Object.getOwnerOf(obj) === bob;
+      name: 'setOwnerOf',
+      src: `
+      var bob = {};
+      var obj = {};
+      Object.setOwnerOf(obj, bob) === obj && Object.getOwnerOf(obj) === bob;
     `,
     expected: true
   },
@@ -3202,96 +3206,96 @@ module.exports = [
   {
     name: 'new hack with unkown builtin',
     src: `
-    try {
-      new 'nonexistent-builtin-name';
-    } catch (e) {
-      e.name;
-    }
+      try {
+        new 'nonexistent-builtin-name';
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'ReferenceError'
   },
   {
     name: 'new hack with other than string literal',
     src: `
-    try {
-      var builtin = 'Object.prototype';
-      new builtin;
-    } catch (e) {
-      e.name;
-    }
+      try {
+        var builtin = 'Object.prototype';
+        new builtin;
+      } catch (e) {
+        e.name;
+      }
     `,
     expected: 'TypeError'
   },
   {
     name: 'ES6 causes syntax errors',
     src: `
-    var tests = [
-      // Class statements & expressions
-      'class Foo{};',
-      'false && class Foo{};',
-      // Arrow functions.
-      'false && [].map((item) => String(item));',
-      // For-of statement.
-      'for (var x of [1, 2, 3]) {};',
-      // Let & const.
-      'let x;',
-      'const x;',
-    ];
-    var failed = [];
-    for (var i = 0; i < tests.length; i++) {
-      try {
-        eval(tests[i]);
-        failed.push("Didn't throw: " + tests[i]);
-      } catch (e) {
-        if (e.name !== 'SyntaxError') {
-          failed.push('Wrong error: ' + tests[i] + ' threw ' + String(e));
+      var tests = [
+        // Class statements & expressions
+        'class Foo{};',
+        'false && class Foo{};',
+        // Arrow functions.
+        'false && [].map((item) => String(item));',
+        // For-of statement.
+        'for (var x of [1, 2, 3]) {};',
+        // Let & const.
+        'let x;',
+        'const x;',
+      ];
+      var failed = [];
+      for (var i = 0; i < tests.length; i++) {
+        try {
+          eval(tests[i]);
+          failed.push("Didn't throw: " + tests[i]);
+        } catch (e) {
+          if (e.name !== 'SyntaxError') {
+            failed.push('Wrong error: ' + tests[i] + ' threw ' + String(e));
+          }
         }
       }
-    }
-    failed.length ? failed.join('\\n') : 'OK';
+      failed.length ? failed.join('\\n') : 'OK';
     `,
     expected: 'OK'
   },
   {
     name: 'Strict mode syntax errors',
     src: `
-    var tests = [
-      // With statement.
-      'var o = {foo: 42}; var f = function() {with (o) {foo;}};',
-      // Binding eval in global scope, or arguments in a function.
-      'var eval = "rebinding eval?!?";',
-      '(function() {arguments = undefined;});',
-      // Duplicate argument names.
-      '(function(a, a) {});',
-      // Octal numeric literals.
-      '0777;',
-      // Delete of unqualified or undeclared identifier.
-      'var foo; delete foo;',
-      'delete foo;',
-    ];
-    var failed = [];
-    for (var i = 0; i < tests.length; i++) {
-      try {
-        eval(tests[i]);
-        failed.push("Didn't throw: " + tests[i]);
-      } catch (e) {
-        if (e.name !== 'SyntaxError') {
-          failed.push('Wrong error: ' + tests[i] + ' threw ' + String(e));
+      var tests = [
+        // With statement.
+        'var o = {foo: 42}; var f = function() {with (o) {foo;}};',
+        // Binding eval in global scope, or arguments in a function.
+        'var eval = "rebinding eval?!?";',
+        '(function() {arguments = undefined;});',
+        // Duplicate argument names.
+        '(function(a, a) {});',
+        // Octal numeric literals.
+        '0777;',
+        // Delete of unqualified or undeclared identifier.
+        'var foo; delete foo;',
+        'delete foo;',
+      ];
+      var failed = [];
+      for (var i = 0; i < tests.length; i++) {
+        try {
+          eval(tests[i]);
+          failed.push("Didn't throw: " + tests[i]);
+        } catch (e) {
+          if (e.name !== 'SyntaxError') {
+            failed.push('Wrong error: ' + tests[i] + ' threw ' + String(e));
+          }
         }
       }
-    }
-    failed.length ? failed.join('\\n') : 'OK';
+      failed.length ? failed.join('\\n') : 'OK';
     `,
     expected: 'OK'
   },
   {
     name: 'Stack overflow errors',
     src: `
-    try {
-      (function f() {f();})();
-    } catch (e) {
-      e.name;
-    }
+      try {
+        (function f() {f();})();
+      } catch (e) {
+        e.name;
+      }
     `,
     options: {stackLimit: 100},
     expected: 'RangeError'
@@ -3299,15 +3303,15 @@ module.exports = [
   {
     name: 'Minimum stack depth limit',
     src: `
-    function f() {
-      try {
-        return f() + 1;
-      } catch (e) {
-        return 1;
+      function f() {
+        try {
+          return f() + 1;
+        } catch (e) {
+          return 1;
+        }
       }
-    }
-    var limit = f();
-    limit > 100 ? 'OK' : limit;
+      var limit = f();
+      limit > 100 ? 'OK' : limit;
     `,
     options: {stackLimit: 1000},
     expected: 'OK'

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -23,173 +23,227 @@
 
 module.exports = [
   // Testcases for TestInterpreterSimple (have expected value):
-  { name: 'onePlusOne', src: `
+  {
+    name: 'onePlusOne',
+    src: `
     1 + 1;
     `,
-    expected: 2 },
-
-  { name: 'twoPlusTwo', src: `
+    expected: 2
+  },
+  {
+    name: 'twoPlusTwo',
+    src: `
     2 + 2;
     `,
-    expected: 4 },
-
-  { name: 'sixTimesSeven', src: `
+    expected: 4
+  },
+  {
+    name: 'sixTimesSeven',
+    src: `
     6 * 7;
     `,
-    expected: 42 },
-
-  { name: 'simpleFourFunction', src: `
+    expected: 42
+  },
+  {
+    name: 'simpleFourFunction',
+    src: `
     (3 + 12 / 4) * (10 - 3);
     `,
-    expected: 42 },
-
-  { name: 'variableDecl', src: `
+    expected: 42
+  },
+  {
+    name: 'variableDecl',
+    src: `
     var x = 43;
     x;
     `,
-    expected: 43 },
-
-  { name: 'condTrue', src: `
+    expected: 43
+  },
+  {
+    name: 'condTrue',
+    src: `
     true ? 'then' : 'else';
     `,
-    expected: 'then' },
-
-  { name: 'condFalse', src: `
+    expected: 'then'
+  },
+  {
+    name: 'condFalse',
+    src: `
     false ? 'then' : 'else';
     `,
-    expected: 'else' },
-
-  { name: 'ifTrue', src: `
+    expected: 'else'
+  },
+  {
+    name: 'ifTrue',
+    src: `
     if (true) {
       'then';
     } else {
       'else';
     }
     `,
-    expected: 'then' },
-
-  { name: 'ifFalse', src: `
+    expected: 'then'
+  },
+  {
+    name: 'ifFalse',
+    src: `
     if (false) {
       'then';
     } else {
       'else';
     }
     `,
-    expected: 'else' },
-
-  { name: 'simpleAssignment', src: `
+    expected: 'else'
+  },
+  {
+    name: 'simpleAssignment',
+    src: `
     var x = 0;
     x = 44;
     x;
     `,
-    expected: 44 },
-
-  { name: 'propertyAssignment', src: `
+    expected: 44
+  },
+  {
+    name: 'propertyAssignment',
+    src: `
     var o = {};
     o.foo = 45;
     o.foo;
     `,
-    expected: 45 },
-
-  { name: 'getPropertyOnPrimitive', src: `
+    expected: 45
+  },
+  {
+    name: 'getPropertyOnPrimitive',
+    src: `
     'foo'.length;
     `,
-    expected: 3 },
-
-  { name: 'setPropertyOnPrimitive', src: `
+    expected: 3
+  },
+  {
+    name: 'setPropertyOnPrimitive',
+    src: `
     try {
       'foo'.bar = 42;
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'postincrement', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'postincrement',
+    src: `
     var x = 45;
     x++;
     x++;
     `,
-    expected: 46 },
-
-  { name: 'preincrement', src: `
+    expected: 46
+  },
+  {
+    name: 'preincrement',
+    src: `
     var x = 45;
     ++x;
     ++x;
     `,
-    expected: 47 },
-
-  { name: 'concat', src: `
+    expected: 47
+  },
+  {
+    name: 'concat',
+    src: `
     'foo' + 'bar';
     `,
-    expected: 'foobar' },
-
-  { name: 'plusequalsLeft', src: `
+    expected: 'foobar'
+  },
+  {
+    name: 'plusequalsLeft',
+    src: `
     var x = 40, y = 8;
     x += y;
     x;
     `,
-  expected: 48 },
-
-  { name: 'plusequalsRight', src: `
+    expected: 48
+  },
+  {
+    name: 'plusequalsRight',
+    src: `
     var x = 40, y = 8;
     x += y;
     y;
     `,
-    expected: 8 },
-
-  { name: 'simpleFunctionExpression', src: `
+    expected: 8
+  },
+  {
+    name: 'simpleFunctionExpression',
+    src: `
     var v;
     var f = function() { v = 49; };
     f();
     v;
     `,
-    expected: 49 },
-
-  { name: 'assignmentSetsAnonFuncName', src: `
+    expected: 49
+  },
+  {
+    name: 'assignmentSetsAnonFuncName',
+    src: `
     var myAssignedFunc;
     myAssignedFunc = function() {};
     myAssignedFunc.name;
     `,
-    expected: 'myAssignedFunc' },
-
-  { name: 'objectExprSetsAnonFuncName', src: `
+    expected: 'myAssignedFunc'
+  },
+  {
+    name: 'objectExprSetsAnonFuncName',
+    src: `
     var o = {myPropFunc: function() {}};
     o.myPropFunc.name;
     `,
-    expected: 'myPropFunc' },
-
-  { name: 'varDeclSetsAnonFuncName', src: `
+    expected: 'myPropFunc'
+  },
+  {
+    name: 'varDeclSetsAnonFuncName',
+    src: `
     var myVarDeclFunc = function() {};
     myVarDeclFunc.name;
     `,
-    expected: 'myVarDeclFunc' },
-
-  { name: 'funExpWithParameter', src: `
+    expected: 'myVarDeclFunc'
+  },
+  {
+    name: 'funExpWithParameter',
+    src: `
     var v;
     var f = function(x) { v = x; };
     f(50);
     v;
     `,
-    expected: 50 },
-
-  { name: 'funExpParameterNotShadowedByVar', src: `
+    expected: 50
+  },
+  {
+    name: 'funExpParameterNotShadowedByVar',
+    src: `
     var f = function(x) { var x; return x; };
     f(50.1);
     `,
-    expected: 50.1 },
-
-  { name: 'functionWithReturn', src: `
+    expected: 50.1
+  },
+  {
+    name: 'functionWithReturn',
+    src: `
     (function(x) { return x; })(51);
     `,
-    expected: 51 },
-
-  { name: 'functionWithoutReturn', src: `
+    expected: 51
+  },
+  {
+    name: 'functionWithoutReturn',
+    src: `
     (function() {})();
     `,
-    expected: undefined },
-
-  { name: 'multipleReturn', src: `
+    expected: undefined
+  },
+  {
+    name: 'multipleReturn',
+    src: `
     var f = function() {
       try {
         return true;
@@ -199,9 +253,11 @@ module.exports = [
     }
     f();
     `,
-    expected: false },
-
-  { name: 'throwCatch', src: `
+    expected: false
+  },
+  {
+    name: 'throwCatch',
+    src: `
     var f = function() {
       throw 26;
     }
@@ -211,86 +267,108 @@ module.exports = [
       e * 2;
     }
     `,
-    expected: 52 },
-
-  { name: 'throwCatchFalsey', src: `
+    expected: 52
+  },
+  {
+    name: 'throwCatchFalsey',
+    src: `
     try {
       throw null;
     } catch (e) {
       'caught ' + String(e);
     }
     `,
-    expected: 'caught null' },
-
+    expected: 'caught null'
+  },
   // N.B.: This and next tests have no equivalent in the test DB.
-  { name: 'throwUnhandledError', src: `
+  {
+    name: 'throwUnhandledError',
+    src: `
     throw new Error('not caught');
     `,
     options: {noLog: ['unhandled']},
-    expected: undefined },
-
-  { name: 'throwUnhandledException', src: `
+    expected: undefined
+  },
+  {
+    name: 'throwUnhandledException',
+    src: `
     throw 'not caught';
     `,
     options: {noLog: ['unhandled']},
-    expected: undefined },
-
-  { name: 'throwUnhandledErrorWithFinally', src: `
+    expected: undefined
+  },
+  {
+    name: 'throwUnhandledErrorWithFinally',
+    src: `
     try {
       throw new Error('not caught');
     } finally {
     }
     `,
     options: {noLog: ['unhandled']},
-    expected: undefined },
-
-  { name: 'throwUnhandledExceptionWithFinally', src: `
+    expected: undefined
+  },
+  {
+    name: 'throwUnhandledExceptionWithFinally',
+    src: `
     try {
       throw 'not caught';
     } finally {
     }
     `,
     options: {noLog: ['unhandled']},
-    expected: undefined },
-
-  { name: 'seqExpr', src: `
+    expected: undefined
+  },
+  {
+    name: 'seqExpr',
+    src: `
     51, 52, 53;
     `,
-    expected: 53 },
-
-  { name: 'labeledStatement', src: `
+    expected: 53
+  },
+  {
+    name: 'labeledStatement',
+    src: `
     foo: 54;
     `,
-    expected: 54 },
-
-  { name: 'whileLoop', src: `
+    expected: 54
+  },
+  {
+    name: 'whileLoop',
+    src: `
     var a = 0;
     while (a < 55) {
       a++;
     }
     a;
     `,
-    expected: 55 },
-
-  { name: 'whileFalse', src: `
+    expected: 55
+  },
+  {
+    name: 'whileFalse',
+    src: `
     var a = 56;
     while (false) {
       a++;
     }
     a;
     `,
-    expected: 56 },
-
-  { name: 'doWhileFalse', src: `
+    expected: 56
+  },
+  {
+    name: 'doWhileFalse',
+    src: `
     var a = 56;
     do {
       a++;
     } while (false);
     a;
     `,
-    expected: 57 },
-
-  { name: 'breakDoWhile', src: `
+    expected: 57
+  },
+  {
+    name: 'breakDoWhile',
+    src: `
     var a = 57;
     do {
       a++;
@@ -299,14 +377,18 @@ module.exports = [
     } while (false);
     a;
     `,
-    expected: 58 },
-
-  { name: 'selfBreak', src: `
+    expected: 58
+  },
+  {
+    name: 'selfBreak',
+    src: `
     foo: break foo;
     `,
-    expected: undefined /* (but legal!) */ },
-
-  { name: 'breakWithFinally', src: `
+    expected: undefined /* (but legal!) */
+  },
+  {
+    name: 'breakWithFinally',
+    src: `
     var a = 6;
     foo: {
       try {
@@ -320,8 +402,9 @@ module.exports = [
     `,
     expected: 59
   },
-
-  { name: 'continueWithFinally', src: `
+  {
+    name: 'continueWithFinally',
+    src: `
     var a = 59;
     do {
       try {
@@ -334,8 +417,9 @@ module.exports = [
     `,
     expected: 60
   },
-
-  { name: 'breakWithFinallyContinue', src: `
+  {
+    name: 'breakWithFinallyContinue',
+    src: `
     var a = 0;
     while (a++ < 60) {
       try {
@@ -348,8 +432,9 @@ module.exports = [
     `,
     expected: 61
   },
-
-  { name: 'returnWithFinallyContinue', src: `
+  {
+    name: 'returnWithFinallyContinue',
+    src: `
     (function() {
       var i = 0;
       while (i++ < 61) {
@@ -364,90 +449,115 @@ module.exports = [
     `,
     expected: 62
   },
-
-  { name: 'orTrue', src: `
+  {
+    name: 'orTrue',
+    src: `
     63 || 'foo';
     `,
-    expected: 63 },
-
-  { name: 'orFalse', src: `
+    expected: 63
+  },
+  {
+    name: 'orFalse',
+    src: `
     false || 64;
     `,
-    expected: 64 },
-
-  { name: 'orShortcircuit', src: `
+    expected: 64
+  },
+  {
+    name: 'orShortcircuit',
+    src: `
     var r = 0;
     true || (r++);
     r;
     `,
-    expected: 0 },
-
-  { name: 'andTrue', src: `
+    expected: 0
+  },
+  {
+    name: 'andTrue',
+    src: `
     ({}) && 65;
     `,
-    expected: 65 },
-
-  { name: 'andFalse', src: `
+    expected: 65
+  },
+  {
+    name: 'andFalse',
+    src: `
     0 && 65;
     `,
-    expected: 0 },
-
-  { name: 'andShortcircuit', src: `
+    expected: 0
+  },
+  {
+    name: 'andShortcircuit',
+    src: `
     var r = 0;
     false && (r++);
     r;
     `,
-    expected: 0 },
-
-  { name: 'sequenceExpresion', src: `
+    expected: 0
+  },
+  {
+    name: 'sequenceExpresion',
+    src: `
     var x, y, z;
     x = (y = 60, z = 5, 0.5);
     x + y + z;
     `,
-    expected: 65.5 },
-
-  { name: 'forTriangular', src: `
+    expected: 65.5
+  },
+  {
+    name: 'forTriangular',
+    src: `
     var t = 0;
     for (var i = 0; i < 12; i++) {
       t += i;
     }
     t;
     `,
-    expected: 66 },
-
-  { name: 'forIn', src: `
+    expected: 66
+  },
+  {
+    name: 'forIn',
+    src: `
     var x = 0, a = {a: 60, b:3, c:4};
     for (var i in a) { x += a[i]; }
     x;
     `,
-    expected: 67 },
-
-  { name: 'forInMemberExp', src: `
+    expected: 67
+  },
+  {
+    name: 'forInMemberExp',
+    src: `
     var x = 1, o = {foo: 'bar'}, a = {a:2, b:2, c:17};
     for (o.foo in a) { x *= a[o.foo]; }
     x;
     `,
-    expected: 68 },
-
-  { name: 'forInMembFunc', src: `
+    expected: 68
+  },
+  {
+    name: 'forInMembFunc',
+    src: `
     var x = 0, o = {};
     var f = function() { x += 20; return o; };
     var a = {a:2, b:3, c:4};
     for (f().foo in a) { x += a[o.foo]; }
     x;
     `,
-    expected: 69 },
-
-  { name: 'forInNullUndefined', src: `
+    expected: 69
+  },
+  {
+    name: 'forInNullUndefined',
+    src: `
     var x = 0, o = {};
     var f = function() { x++; return o; };
     for (f().foo in null) { x++; }
     for (f().foo in undefined) { x++; }
     x;
     `,
-    expected: 0 },
-
-  { name: 'switchDefaultFirst', src: `
+    expected: 0
+  },
+  {
+    name: 'switchDefaultFirst',
+    src: `
     switch ('not found') {
       default:
         'OK';
@@ -456,17 +566,21 @@ module.exports = [
         'fail';
     };
     `,
-    expected: 'OK' },
-
-  { name: 'switchDefaultOnly', src: `
+    expected: 'OK'
+  },
+  {
+    name: 'switchDefaultOnly',
+    src: `
     switch ('not found') {
       default:
         'OK';
     };
     `,
-    expected: 'OK' },
-
-  { name: 'switchEmptyToEnd', src: `
+    expected: 'OK'
+  },
+  {
+    name: 'switchEmptyToEnd',
+    src: `
     'ok';
     switch ('foo') {
       default:
@@ -475,53 +589,69 @@ module.exports = [
       case 'bar':
     };
     `,
-    expected: 'ok' },
-
-  { name: 'thisInMethod', src: `
+    expected: 'ok'
+  },
+  {
+    name: 'thisInMethod',
+    src: `
     var o = {
       f: function() { return this.foo; },
       foo: 70
     };
     o.f();
     `,
-    expected: 70 },
-
-  { name: 'thisInFormerMethod', src: `
+    expected: 70
+  },
+  {
+    name: 'thisInFormerMethod',
+    src: `
     var o = { f: function() { return this; }};
     var g = o.f;
     g();
     `,
-    expected: undefined },
-
-  { name: 'thisGlobal', src: `
+    expected: undefined
+  },
+  {
+    name: 'thisGlobal',
+    src: `
     this;
     `,
-    expected: undefined },
-
-  { name: 'emptyArrayLength', src: `
+    expected: undefined
+  },
+  {
+    name: 'emptyArrayLength',
+    src: `
     [].length;
     `,
-    expected: 0 },
-
-  { name: 'arrayElidedLength', src: `
+    expected: 0
+  },
+  {
+    name: 'arrayElidedLength',
+    src: `
     [1,,3,,].length;
     `,
-    expected: 4 },
-
-  { name: 'arrayElidedNotDefinedNotUndefined', src: `
+    expected: 4
+  },
+  {
+    name: 'arrayElidedNotDefinedNotUndefined',
+    src: `
     var a = [,undefined,null,0,false];
     !(0 in a) && (1 in a) && (2 in a) && (3 in a) && (4 in a);
     `,
-    expected: true },
-
-  { name: 'arrayLengthPropertyDescriptor', src: `
+    expected: true
+  },
+  {
+    name: 'arrayLengthPropertyDescriptor',
+    src: `
     var a = [1, 2, 3];
     var pd = Object.getOwnPropertyDescriptor(a, 'length');
     (pd.value === 3) && pd.writable && !pd.enumerable && !pd.configurable;
     `,
-    expected: true },
-
-  { name: 'arrayLength', src: `
+    expected: true
+  },
+  {
+    name: 'arrayLength',
+    src: `
     try {
       var a;
       function checkLen(exp, desc) {
@@ -530,21 +660,17 @@ module.exports = [
           throw new Error(desc ? msg + ' ' + desc : msg);
         }
       }
-
       // Empty array has length == 0
       a = [];
       checkLen(0, 'on empty array');
-
       // Adding non-numeric properties does not increase length:
       a['zero'] = 0;
       checkLen(0, 'after setting non-index property on []');
-
       // Adding numeric properties >= length does increase length:
       for (var i = 0; i < 5; i++) {
         a[i] = i;
         checkLen(i + 1, 'after setting a[' + i + ']');
       }
-
       // .length works propery even for large, sparse arrays, and even
       // if values are undefined:
       for (i = 3; i <= 31; i++) {
@@ -552,11 +678,9 @@ module.exports = [
         a[idx] = undefined;
         checkLen(idx + 1, 'after setting a[' + idx + ']');
       }
-
       // Adding numeric properties < length does not increase length:
       a[idx - 1] = 'not the largest';
       checkLen(idx + 1, 'after setting non-largest element');
-
       // Verify behaviour around largest possible index:
       a[0xfffffffd] = null;
       checkLen(0xfffffffe);
@@ -566,7 +690,6 @@ module.exports = [
       checkLen(0xffffffff);  // Unchanged.
       a[0x100000000] = null; // Not an index.
       checkLen(0xffffffff);  // Unchanged.
-
       function checkIdx(idx, exp, desc) {
         var r = a.hasOwnProperty(idx);
         if (r !== exp) {
@@ -574,14 +697,12 @@ module.exports = [
           throw new Error(desc ? msg + ' ' + desc : msg);
         }
       }
-
       // Setting length to existing value should have no effect:
       a.length = 0xffffffff;
       checkIdx(0xfffffffd, true);
       checkIdx(0xfffffffe, true);
       checkIdx(0xffffffff, true);
       checkIdx(0x100000000, true);
-
       // Setting length one less than maximum should remove largest
       // index, but leave properties with keys too large to be indexes:
       a.length = 0xfffffffe;
@@ -589,7 +710,6 @@ module.exports = [
       checkIdx(0xfffffffe, false);
       checkIdx(0xffffffff, true);
       checkIdx(0x100000000, true);
-
       // Setting length to zero should remove all index properties:
       a.length = 0;
       for (var key in a) {
@@ -601,7 +721,6 @@ module.exports = [
               'Setting a.length = 0 failed to remove property ' + key);
         }
       }
-
       // Make sure we didn't wipe everything!
       if (Object.getOwnPropertyNames(a).length !== 4) {
         throw new Error(
@@ -612,18 +731,22 @@ module.exports = [
       String(e);
     }
     `,
-    expected: 'OK' },
-
-  { name: 'arrayLengthWithNonWritableProps', src: `
+    expected: 'OK'
+  },
+  {
+    name: 'arrayLengthWithNonWritableProps',
+    src: `
     var a = [];
     Object.defineProperty(a, 0,
         {value: 'hi', writable: false, configurable: true});
     a.length = 0;
     a[0] === undefined && a.length === 0;
     `,
-    expected: true },
-
-  { name: 'arrayLengthWithNonConfigurableProps', src: `
+    expected: true
+  },
+  {
+    name: 'arrayLengthWithNonConfigurableProps',
+    src: `
     var a = [];
     Object.defineProperty(a, 0,
         {value: 'hi', writable: false, configurable: false});
@@ -633,45 +756,61 @@ module.exports = [
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'compValEmptyBlock', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'compValEmptyBlock',
+    src: `
     {};
     `,
-    expected: undefined },
-
-  { name: 'undefined', src: `
+    expected: undefined
+  },
+  {
+    name: 'undefined',
+    src: `
     undefined;
     `,
-    expected: undefined },
-
-  { name: 'unaryVoid', src: `
+    expected: undefined
+  },
+  {
+    name: 'unaryVoid',
+    src: `
     var x = 70;
     (undefined === void x++) && x;
     `,
-    expected: 71 },
-
-  { name: 'unaryPlus', src: `
+    expected: 71
+  },
+  {
+    name: 'unaryPlus',
+    src: `
     +'72';
     `,
-    expected: 72 },
-
-  { name: 'unaryMinus', src: `
+    expected: 72
+  },
+  {
+    name: 'unaryMinus',
+    src: `
     -73;
     `,
-    expected: -73 },
-
-  { name: 'unaryComplement', src: `
+    expected: -73
+  },
+  {
+    name: 'unaryComplement',
+    src: `
     ~0xffffffb5;
     `,
-    expected: 74 },
-
-  { name: 'unaryNot', src: `
+    expected: 74
+  },
+  {
+    name: 'unaryNot',
+    src: `
     !false && (!true === false);
     `,
-    expected: true },
-
-  { name: 'unaryTypeof', src: `
+    expected: true
+  },
+  {
+    name: 'unaryTypeof',
+    src: `
     var tests = [
       [undefined, 'undefined'],
       [null, 'object'],
@@ -690,68 +829,86 @@ module.exports = [
     }
     (ok === tests.length) ? 'pass' : 'fail';
     `,
-    expected: 'pass' },
-
-  { name: 'unaryTypeofUndeclared', src: `
+    expected: 'pass'
+  },
+  {
+    name: 'unaryTypeofUndeclared',
+    src: `
     try {
       typeof undeclaredVar;
     } catch (e) {
       'whoops!'
     }
     `,
-    expected: 'undefined' },
-
-  { name: 'binaryIn', src: `
+    expected: 'undefined'
+  },
+  {
+    name: 'binaryIn',
+    src: `
     var o = {foo: 'bar'};
     'foo' in o && !('bar' in o);
     `,
-    expected: true },
-
-  { name: 'binaryInParent', src: `
+    expected: true
+  },
+  {
+    name: 'binaryInParent',
+    src: `
     var p = {foo: 'bar'};
     var o = Object.create(p);
     'foo' in o && !('bar' in o);
     `,
-    expected: true },
-
-  { name: 'binaryInArrayLength', src: `
+    expected: true
+  },
+  {
+    name: 'binaryInArrayLength',
+    src: `
     'length' in [];
     `,
-    expected: true },
-
-  { name: 'binaryInStringLength', src: `
+    expected: true
+  },
+  {
+    name: 'binaryInStringLength',
+    src: `
     try {
       'length' in '';
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'instanceofBasics', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'instanceofBasics',
+    src: `
     function F(){}
     var f = new F;
     f instanceof F && f instanceof Object && !(f.prototype instanceof F);
     `,
-    expected: true },
-
-  { name: 'instanceofNonObjectLHS', src: `
+    expected: true
+  },
+  {
+    name: 'instanceofNonObjectLHS',
+    src: `
     function F() {}
     F.prototype = null;
     42 instanceof F;
     `,
-    expected: false },
-
-  { name: 'instanceofNonFunctionRHS', src: `
+    expected: false
+  },
+  {
+    name: 'instanceofNonFunctionRHS',
+    src: `
     try {
       ({}) instanceof 0;
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'instanceofNonObjectPrototype', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'instanceofNonObjectPrototype',
+    src: `
     function F() {};
     F.prototype = 'hello';
     try {
@@ -760,18 +917,22 @@ module.exports = [
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'undefined.foo', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'undefined.foo',
+    src: `
     try {
       undefined.foo;
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'undefined.foo = ...', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'undefined.foo = ...',
+    src: `
     try {
       var c = 0;
       undefined.foo = c++;
@@ -779,18 +940,22 @@ module.exports = [
       e.name + ',' + c;
     }
     `,
-    expected: 'TypeError,0' },
-
-  { name: 'null.foo', src: `
+    expected: 'TypeError,0'
+  },
+  {
+    name: 'null.foo',
+    src: `
     try {
       null.foo;
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'null.foo = ...', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'null.foo = ...',
+    src: `
     try {
       var c = 0;
       null.foo = c++;
@@ -798,37 +963,45 @@ module.exports = [
       e.name + ',' + c;
     }
     `,
-    expected: 'TypeError,0' },
-
-  { name: 'deleteProp', src: `
+    expected: 'TypeError,0'
+  },
+  {
+    name: 'deleteProp',
+    src: `
     var o = {foo: 'bar'};
     (delete o.quux) + ('foo' in o) + (delete o.foo) +
         !('foo' in o) + (delete o.foo);
     `,
-    expected: 5 },
-
-  { name: 'deleteNonexistentFromPrimitive', src: `
+    expected: 5
+  },
+  {
+    name: 'deleteNonexistentFromPrimitive',
+    src: `
     (delete false.nonexistent) &&
     (delete (42).toString);
     `,
-    expected: true },
-
+    expected: true
+  },
   // This "actually" tries to delete the non-configurable own .length
   // property from the auto-boxed String instance created by step 4a
   // of algorithm in §11.4.1 of the ES 5.1 spec.  We have to use a
   // string here, because only String instances have own properties
   // (and yes: they are all non-configurable, so delete *always*
   // fails).
-  { name: 'deleteOwnFromPrimitive', src: `
+  {
+    name: 'deleteOwnFromPrimitive',
+    src: `
     try {
       delete 'hello'.length;
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'funcDecl', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'funcDecl',
+    src: `
     var v;
     function f() {
       v = 75;
@@ -836,9 +1009,11 @@ module.exports = [
     f();
     v;
     `,
-    expected: 75 },
-
-  { name: 'namedFunctionExpression', src: `
+    expected: 75
+  },
+  {
+    name: 'namedFunctionExpression',
+    src: `
     var f = function half(x) {
       if (x < 100) {
         return x;
@@ -847,21 +1022,27 @@ module.exports = [
     };
     f(152)
     `,
-    expected: 76 },
-
-  { name: 'namedFunExpNameBinding', src: `
+    expected: 76
+  },
+  {
+    name: 'namedFunExpNameBinding',
+    src: `
     var f = function foo() {return foo;};
     f() === f;
     `,
-    expected: true },
-
-  { name: 'namedFunExpNameBindingNoLeak', src: `
+    expected: true
+  },
+  {
+    name: 'namedFunExpNameBindingNoLeak',
+    src: `
     var f = function foo() {};
     typeof foo;
     `,
-    expected: 'undefined' },
-
-  { name: 'namedFunExpNameBindingImmutable', src: `
+    expected: 'undefined'
+  },
+  {
+    name: 'namedFunExpNameBindingImmutable',
+    src: `
     var f = function foo() {
       try {
         foo = null;
@@ -871,18 +1052,22 @@ module.exports = [
     };
     f();
     `,
-    expected: 'TypeError' },
-
-  { name: 'namedFunExpNameBindingShadowedByParam', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'namedFunExpNameBindingShadowedByParam',
+    src: `
     var f = function foo(foo) {
       foo += 0.1;  // Verify mutability.
       return foo;
     };
     f(76);
     `,
-    expected: 76.1 },
-
-  { name: 'namedFunExpNameBindingShadowedByVar', src: `
+    expected: 76.1
+  },
+  {
+    name: 'namedFunExpNameBindingShadowedByVar',
+    src: `
     var f = function foo() {
       var foo;
       foo = 76.2;  // Verify mutability.
@@ -890,9 +1075,11 @@ module.exports = [
     };
     f();
     `,
-    expected: 76.2 },
-
-  { name: 'closureIndependence', src: `
+    expected: 76.2
+  },
+  {
+    name: 'closureIndependence',
+    src: `
     function makeAdder(x) {
       return function(y) { return x + y; };
     }
@@ -900,18 +1087,22 @@ module.exports = [
     var plus4 = makeAdder(4);
     plus3(plus4(70));
     `,
-    expected: 77 },
-
-  { name: 'internalObjectToString', src: `
+    expected: 77
+  },
+  {
+    name: 'internalObjectToString',
+    src: `
     var o = {};
     o[{}] = null;
     for(var key in o) {
       key;
     }
     `,
-    expected: '[object Object]' },
-
-  { name: 'internalFunctionToString', src: `
+    expected: '[object Object]'
+  },
+  {
+    name: 'internalFunctionToString',
+    src: `
     var o = {}, s, f = function(){};
     o[f] = null;
     for(var key in o) {
@@ -919,9 +1110,11 @@ module.exports = [
     }
     /^function.*\(.*\).*{[^]*}$/.test(s);
     `,
-    expected: true },
-
-  { name: 'internalNativeFuncToString', src: `
+    expected: true
+  },
+  {
+    name: 'internalNativeFuncToString',
+    src: `
     var o = {}, s, f = Object.create;
     o[f] = null;
     for(var key in o) {
@@ -929,45 +1122,55 @@ module.exports = [
     }
     /^function.*\(.*\).*{[^]*}$/.test(s);
     `,
-    expected: true },
-
-  { name: 'internalArrayToString', src: `
+    expected: true
+  },
+  {
+    name: 'internalArrayToString',
+    src: `
     var o = {};
     o[[1, 2, 3]] = null;
     for(var key in o) {
       key;
     }
     `,
-    expected: '1,2,3' },
-
-  { name: 'internalDateToString', src: `
+    expected: '1,2,3'
+  },
+  {
+    name: 'internalDateToString',
+    src: `
     var o = {};
     o[new Date(0)] = null;
     for(var key in o) {
       key;
     }
     `,
-    expected: (new Date(0)).toString() },
-
-  { name: 'internalRegExpToString', src: `
+    expected: (new Date(0)).toString()
+  },
+  {
+    name: 'internalRegExpToString',
+    src: `
     var o = {};
     o[/foo/g] = null;
     for(var key in o) {
       key;
     }
     `,
-    expected: '/foo/g' },
-
-  { name: 'internalErrorToString', src: `
+    expected: '/foo/g'
+  },
+  {
+    name: 'internalErrorToString',
+    src: `
     var o = {};
     o[Error('oops')] = null;
     for(var key in o) {
       key;
     }
     `,
-    expected: 'Error: oops' },
-
-  { name: 'internalArgumentsToString', src: `
+    expected: 'Error: oops'
+  },
+  {
+    name: 'internalArgumentsToString',
+    src: `
     var o = {};
     (function() {
       o[arguments] = null;
@@ -978,46 +1181,59 @@ module.exports = [
     `,
     expected: '[object Arguments]'
   },
-
-  { name: 'debugger', src: `
+  {
+    name: 'debugger',
+    src: `
     debugger;
     `,
-    expected: undefined },
-
-  { name: 'newExpression', src: `
+    expected: undefined
+  },
+  {
+    name: 'newExpression',
+    src: `
     function T(x, y) { this.sum += x + y; };
     T.prototype = { sum: 70 }
     var t = new T(7, 0.7);
     t.sum;
     `,
-    expected: 77.7 },
-
-  { name: 'newExpressionReturnObj', src: `
+    expected: 77.7
+  },
+  {
+    name: 'newExpressionReturnObj',
+    src: `
     function T() { return {}; };
     T.prototype = { p: 'the prototype' };
     (new T).p;
     `,
-    expected: undefined },
-
-  { name: 'newExpressionReturnPrimitive', src: `
+    expected: undefined
+  },
+  {
+    name: 'newExpressionReturnPrimitive',
+    src: `
     function T() { return 0; };
     T.prototype = { p: 'the prototype' };
     (new T).p;
     `,
-    expected: 'the prototype' },
-
-  { name: 'regexpSimple', src: `
+    expected: 'the prototype'
+  },
+  {
+    name: 'regexpSimple',
+    src: `
     /foo/.test('foobar');
     `,
-    expected: true },
-
-  { name: 'evalSeeEnclosing', src: `
+    expected: true
+  },
+  {
+    name: 'evalSeeEnclosing',
+    src: `
     var n = 77.77;
     eval('n');
     `,
-    expected: 77.77 },
-
-  { name: 'evalIndirectNoSeeEnclosing', src: `
+    expected: 77.77
+  },
+  {
+    name: 'evalIndirectNoSeeEnclosing',
+    src: `
     (function() {
       var n = 77.77, gEval = eval;
       try {
@@ -1027,9 +1243,11 @@ module.exports = [
       }
     })();
     `,
-    expected: 'ReferenceError' },
-
-  { name: 'evalIndirectNoSeeEnclosing2', src: `
+    expected: 'ReferenceError'
+  },
+  {
+    name: 'evalIndirectNoSeeEnclosing2',
+    src: `
     (function() {
       var n = 77.77;
       try {
@@ -1039,37 +1257,47 @@ module.exports = [
       }
     })();
     `,
-    expected: 'ReferenceError' },
-
-  { name: 'evalIndirectSeeGlobal', src: `
+    expected: 'ReferenceError'
+  },
+  {
+    name: 'evalIndirectSeeGlobal',
+    src: `
     var gEval = eval;
     gEval('typeof Array');
     `,
-    expected: 'function' },
-
-  { name: 'evalModifyEnclosing', src: `
+    expected: 'function'
+  },
+  {
+    name: 'evalModifyEnclosing',
+    src: `
     var n = 77.77;
     eval('n = 77.88');
     n;
     `,
-    expected: 77.88 },
-
-  { name: 'evalNoLeakingDecls', src: `
+    expected: 77.88
+  },
+  {
+    name: 'evalNoLeakingDecls',
+    src: `
     eval('var n = 88.88');
     typeof n;
     `,
-    expected: 'undefined' },
-
+    expected: 'undefined'
+  },
   // A bug in eval would cause it to return the value of the
   // previously-evaluated ExpressionStatement if the eval program did
   // not contain any ExpressionStatements.
-  { name: 'evalEmptyBlock', src: `
+  {
+    name: 'evalEmptyBlock',
+    src: `
     'fail';
     eval('{}');
     `,
-    expected: undefined },
-
-  { name: 'callEvalOrder', src: `
+    expected: undefined
+  },
+  {
+    name: 'callEvalOrder',
+    src: `
     var r = '';
     function log(x) {
       r += x;
@@ -1078,9 +1306,11 @@ module.exports = [
     (log('f'))(log('a'), log('b'), log('c'));
     r;
     `,
-    expected: 'fabc' },
-
-  { name: 'callEvalArgsBeforeCallability', src: `
+    expected: 'fabc'
+  },
+  {
+    name: 'callEvalArgsBeforeCallability',
+    src: `
     try {
       var invalid = undefined;
       function t() { throw {name: 'args'}; };
@@ -1089,9 +1319,11 @@ module.exports = [
       e.name;
     }
     `,
-    expected: 'args' },
-
-  { name: 'callNonCallable', src: `
+    expected: 'args'
+  },
+  {
+    name: 'callNonCallable',
+    src: `
     var tests = [
       undefined,
       null,
@@ -1113,30 +1345,35 @@ module.exports = [
     }
     (ok === tests.length) ? 'pass' : 'fail';
     `,
-    expected: 'pass' },
-
+    expected: 'pass'
+  },
   /////////////////////////////////////////////////////////////////////////////
   // Object and Object.prototype
-
-  { name: 'Object.defineProperty()', src: `
+  {
+    name: 'Object.defineProperty()',
+    src: `
     try {
       Object.defineProperty();
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.defineProperty non-object', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.defineProperty non-object',
+    src: `
     try {
       Object.defineProperty('not an object', 'foo', {});
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.defineProperty bad descriptor', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.defineProperty bad descriptor',
+    src: `
     var o = {};
     try {
       Object.defineProperty(o, 'foo', 'not an object');
@@ -1144,10 +1381,12 @@ module.exports = [
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
+    expected: 'TypeError'
+  },
   // This also tests iteration over (non-)enumerable properties.
-  { name: 'Object.defineProperty', src: `
+  {
+    name: 'Object.defineProperty',
+    src: `
     var o = { foo: 50 }, r = 0;
     Object.defineProperty(o, 'bar', {
       writable: true,
@@ -1174,9 +1413,11 @@ module.exports = [
     r += Object.getOwnPropertyNames(o).length;
     r;
     `,
-    expected: 78 },
-
-  { name: 'Object.getPrototypeOf(null) and undefined', src: `
+    expected: 78
+  },
+  {
+    name: 'Object.getPrototypeOf(null) and undefined',
+    src: `
     var r = '', prims = [null, undefined];
     for (var i = 0; i < prims.length; i++) {
       try {
@@ -1187,17 +1428,21 @@ module.exports = [
     }
     r;
     `,
-    expected: 'TypeErrorTypeError' },
-
+    expected: 'TypeErrorTypeError'
+  },
   // This tests for ES6 behaviour:
-  { name: 'Object.getPrototypeOf primitives', src: `
+  {
+    name: 'Object.getPrototypeOf primitives',
+    src: `
     Object.getPrototypeOf(true) === Boolean.prototype &&
     Object.getPrototypeOf(1337) === Number.prototype &&
     Object.getPrototypeOf('hi') === String.prototype;
     `,
-    expected: true },
-
-  { name: 'Object.setPrototypeOf(null, ...) and undefined', src: `
+    expected: true
+  },
+  {
+    name: 'Object.setPrototypeOf(null, ...) and undefined',
+    src: `
     var r = '', prims = [null, undefined];
     for (var i = 0; i < prims.length; i++) {
       try {
@@ -1208,32 +1453,40 @@ module.exports = [
     }
     r;
     `,
-    expected: 'TypeErrorTypeError' },
-
-  { name: 'Object.setPrototypeOf primitives', src: `
+    expected: 'TypeErrorTypeError'
+  },
+  {
+    name: 'Object.setPrototypeOf primitives',
+    src: `
     Object.setPrototypeOf(true, null) === true &&
     Object.setPrototypeOf(1337, null) === 1337 &&
     Object.setPrototypeOf('hi', null) === 'hi';
     `,
-    expected: true },
-
-  { name: 'Object.setPrototypeOf', src: `
+    expected: true
+  },
+  {
+    name: 'Object.setPrototypeOf',
+    src: `
     var o = {parent: 'o'};
     var p = {parent: 'p'};
     var q = Object.create(o);
     Object.setPrototypeOf(q, p) === q &&
         Object.getPrototypeOf(q) === p && q.parent;
     `,
-    expected: 'p' },
-
-  { name: 'Object.setPrototypeOf(..., null)', src: `
+    expected: 'p'
+  },
+  {
+    name: 'Object.setPrototypeOf(..., null)',
+    src: `
     var o = {parent: 'o'};
     var q = Object.create(o);
     Object.setPrototypeOf(q, null) === q && Object.getPrototypeOf(q);
     `,
-    expected: null },
-
-  { name: 'Object.setPrototypeOf circular', src: `
+    expected: null
+  },
+  {
+    name: 'Object.setPrototypeOf circular',
+    src: `
     var o = {};
     var p = Object.create(o);
     try {
@@ -1242,82 +1495,102 @@ module.exports = [
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.create()', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.create()',
+    src: `
     try {
       Object.create();
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.create non-object prototype', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.create non-object prototype',
+    src: `
     try {
       Object.create(42);
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.create(null) prototype', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.create(null) prototype',
+    src: `
     var o = Object.create(null);
     Object.getPrototypeOf(o);
     `,
-    expected: null },
-
-  { name: 'Object.create', src: `
+    expected: null
+  },
+  {
+    name: 'Object.create',
+    src: `
     var o = Object.create({foo: 79});
     delete o.foo
     o.foo;
     `,
-    expected: 79 },
-
-  { name: 'Object.getOwnPropertyDescriptor()', src: `
+    expected: 79
+  },
+  {
+    name: 'Object.getOwnPropertyDescriptor()',
+    src: `
     try {
       Object.getOwnPropertyDescriptor();
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.getOwnPropertyDescriptor non-object', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.getOwnPropertyDescriptor non-object',
+    src: `
     try {
       Object.getOwnPropertyDescriptor('not an object', 'foo');
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.getOwnPropertyDescriptor bad keyy', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.getOwnPropertyDescriptor bad keyy',
+    src: `
     var o = {};
     Object.getOwnPropertyDescriptor(o, 'foo');
     `,
-    expected: undefined },
-
-  { name: 'Object.getOwnPropertyDescriptor', src: `
+    expected: undefined
+  },
+  {
+    name: 'Object.getOwnPropertyDescriptor',
+    src: `
     var o = {}, r = 0;
     Object.defineProperty(o, 'foo', { value: 'bar' });
     var desc = Object.getOwnPropertyDescriptor(o, 'foo');
     desc.value === o.foo &&
         !desc.writable && !desc.enumerable && !desc.configurable;
     `,
-    expected: true },
-
-  { name: 'Object.getOwnPropertyNames()', src: `
+    expected: true
+  },
+  {
+    name: 'Object.getOwnPropertyNames()',
+    src: `
     try {
       Object.getOwnPropertyNames();
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.getOwnPropertyNames string', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.getOwnPropertyNames string',
+    src: `
     var i, r = 0, names = Object.getOwnPropertyNames('foo');
     for (i = 0; i < names.length; i++) {
       if (names[i] === 'length') {
@@ -1327,37 +1600,47 @@ module.exports = [
       }
     }
     `,
-    expected: 16 },
-
-  { name: 'Object.getOwnPropertyNames number', src: `
+    expected: 16
+  },
+  {
+    name: 'Object.getOwnPropertyNames number',
+    src: `
     Object.getOwnPropertyNames(42).length
     `,
-    expected: 0 },
-
-  { name: 'Object.getOwnPropertyNames boolean', src: `
+    expected: 0
+  },
+  {
+    name: 'Object.getOwnPropertyNames boolean',
+    src: `
     Object.getOwnPropertyNames(true).length
     `,
-    expected: 0 },
-
-  { name: 'Object.getOwnPropertyNames(null)', src: `
+    expected: 0
+  },
+  {
+    name: 'Object.getOwnPropertyNames(null)',
+    src: `
     try {
       Object.getOwnPropertyNames(null).length;
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.getOwnPropertyNames(undefined)', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.getOwnPropertyNames(undefined)',
+    src: `
     try {
       Object.getOwnPropertyNames(undefined).length;
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.getOwnPropertyNames', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.getOwnPropertyNames',
+    src: `
     var o = Object.create({baz: 999});
     o.foo = 42;
     Object.defineProperty(o, 'bar', { value: 38 });
@@ -1368,36 +1651,44 @@ module.exports = [
     }
     r;
     `,
-    expected: 80 },
-
-  { name: 'Object.defineProperties()', src: `
+    expected: 80
+  },
+  {
+    name: 'Object.defineProperties()',
+    src: `
     try {
       Object.defineProperties();
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.defineProperties non-object', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.defineProperties non-object',
+    src: `
     try {
       Object.defineProperties('not an object', {});
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.defineProperties non-object props', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.defineProperties non-object props',
+    src: `
     try {
       Object.defineProperties({}, undefined);
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.defineProperties bad descriptor', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.defineProperties bad descriptor',
+    src: `
     var o = {};
     try {
       Object.defineProperties(o, { foo: 'not an object' });
@@ -1405,9 +1696,11 @@ module.exports = [
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.defineProperties', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.defineProperties',
+    src: `
     var o = { foo: 70 }, r = 0;
     Object.defineProperties(o, {
         bar: {
@@ -1421,9 +1714,11 @@ module.exports = [
     }
     r + Object.getOwnPropertyNames(o).length;
     `,
-    expected: 81 },
-
-  { name: 'Object.create(..., properties)', src: `
+    expected: 81
+  },
+  {
+    name: 'Object.create(..., properties)',
+    src: `
     var o = Object.create({ foo: 70 }, {
         bar: {
             writable: true,
@@ -1437,14 +1732,18 @@ module.exports = [
     }
     r + Object.getOwnPropertyNames(o).length;
     `,
-    expected: 82 },
-
-  { name: 'Object.prototype.toString', src: `
+    expected: 82
+  },
+  {
+    name: 'Object.prototype.toString',
+    src: `
     ({}).toString();
     `,
-    expected: '[object Object]' },
-
-  { name: 'Object.protoype.hasOwnProperty', src: `
+    expected: '[object Object]'
+  },
+  {
+    name: 'Object.protoype.hasOwnProperty',
+    src: `
     var o = Object.create({baz: 999});
     o.foo = 42;
     Object.defineProperty(o, 'bar', {value: 41, enumerable: true});
@@ -1455,9 +1754,11 @@ module.exports = [
     }
     r;
     `,
-    expected: 83 },
-
-  { name: 'Object.protoype.isPrototypeOf primitives', src: `
+    expected: 83
+  },
+  {
+    name: 'Object.protoype.isPrototypeOf primitives',
+    src: `
     Boolean.prototype.isPrototypeOf(false) ||
     Number.prototype.isPrototypeOf(0) ||
     String.prototype.isPrototypeOf('') ||
@@ -1467,38 +1768,48 @@ module.exports = [
     Object.prototype.isPrototypeOf.call(null, null) ||
     Object.prototype.isPrototypeOf.call(undefined, undefined);
     `,
-    expected: false },
-
-  { name: 'Object.protoype.isPrototypeOf.call(null, ...)', src: `
+    expected: false
+  },
+  {
+    name: 'Object.protoype.isPrototypeOf.call(null, ...)',
+    src: `
     try {
       Object.prototype.isPrototypeOf.call(null, Object.create(null));
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.protoype.isPrototypeOf.call(undefined, ...)', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.protoype.isPrototypeOf.call(undefined, ...)',
+    src: `
     try {
       Object.prototype.isPrototypeOf.call(undefined, Object.create(undefined));
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.protoype.isPrototypeOf self', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.protoype.isPrototypeOf self',
+    src: `
     var o = {};
     o.isPrototypeOf(o);
     `,
-    expected: false },
-
-  { name: 'Object.protoype.isPrototypeOf unrelated', src: `
+    expected: false
+  },
+  {
+    name: 'Object.protoype.isPrototypeOf unrelated',
+    src: `
     Object.prototype.isPrototypeOf(Object.create(null))
     `,
-    expected: false },
-
-  { name: 'Object.protoype.isPrototypeOf related', src: `
+    expected: false
+  },
+  {
+    name: 'Object.protoype.isPrototypeOf related',
+    src: `
     var g = {};
     var p = Object.create(g);
     var o = Object.create(p);
@@ -1506,103 +1817,134 @@ module.exports = [
     g.isPrototypeOf(o) && p.isPrototypeOf(o) &&
     !o.isPrototypeOf(p) && !o.isPrototypeOf(g);
     `,
-    expected: true },
-
-  { name: 'Object.protoype.propertyIsEnumerable(null)', src: `
+    expected: true
+  },
+  {
+    name: 'Object.protoype.propertyIsEnumerable(null)',
+    src: `
     try {
       Object.prototype.propertyIsEnumerable.call(null, '');
     } catch(e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'ObjectProtoypePropertyIsEnumerableUndefined', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'ObjectProtoypePropertyIsEnumerableUndefined',
+    src: `
     try {
       Object.prototype.propertyIsEnumerable.call(undefined, '');
     } catch(e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Object.protoype.propertyIsEnumerable primitives', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Object.protoype.propertyIsEnumerable primitives',
+    src: `
     var OppIE = Object.prototype.propertyIsEnumerable;
     OppIE.call('foo', '0') && !OppIE.call('foo', 'length');
     `,
-    expected: true },
-
-  { name: 'Object.protoype.propertyIsEnumerable', src: `
+    expected: true
+  },
+  {
+    name: 'Object.protoype.propertyIsEnumerable',
+    src: `
     var o = {foo: 'foo'};
     Object.defineProperty(o, 'bar', {value: 'bar', enumerable: false});
     o.propertyIsEnumerable('foo') && !o.propertyIsEnumerable('bar') &&
         !o.propertyIsEnumerable('baz');
     `,
-    expected: true },
-
+    expected: true
+  },
   /////////////////////////////////////////////////////////////////////////////
   // Function and Function.prototype
-
-  { name: 'new Function() returns callable', src: `
+  {
+    name: 'new Function() returns callable',
+    src: `
     (new Function)();
     `,
-    expected: undefined },
-
-  { name: 'new Function() .length', src: `
+    expected: undefined
+  },
+  {
+    name: 'new Function() .length',
+    src: `
     (new Function).length;
     `,
-    expected: 0 },
-
-  { name: 'new Function() .toString()', src: `
+    expected: 0
+  },
+  {
+    name: 'new Function() .toString()',
+    src: `
     String(new Function)
     `,
-    expected: 'function() {}' },
-
-  { name: 'new Function simple returns callable', src: `
+    expected: 'function() {}'
+  },
+  {
+    name: 'new Function simple returns callable',
+    src: `
     (new Function('return 42;'))();
     `,
-    expected: 42 },
-
-  { name: 'new Function simple .length', src: `
+    expected: 42
+  },
+  {
+    name: 'new Function simple .length',
+    src: `
     (new Function('return 42;')).length;
     `,
-    expected: 0 },
-
-  { name: 'new Function simple .toString()', src: `
+    expected: 0
+  },
+  {
+    name: 'new Function simple .toString()',
+    src: `
     String(new Function('return 42;'))
     `,
-    expected: 'function() {return 42;}' },
-
-  { name: 'new Function with args returns callable', src: `
+    expected: 'function() {return 42;}'
+  },
+  {
+    name: 'new Function with args returns callable',
+    src: `
     (new Function('a, b', 'c', 'return a + b * c;'))(2, 3, 10);
     `,
-    expected: 32 },
-
-  { name: 'new Function with args .length', src: `
+    expected: 32
+  },
+  {
+    name: 'new Function with args .length',
+    src: `
     (new Function('a, b', 'c', 'return a + b * c;')).length;
     `,
-    expected: 3 },
-
- { name: 'new Function with args .toString()', src: `
+    expected: 3
+  },
+  {
+    name: 'new Function with args .toString()',
+    src: `
     String(new Function('a, b', 'c', 'return a + b * c;'))
     `,
-    expected: 'function(a, b,c) {return a + b * c;}' },
-
-  { name: 'Function.prototype has no .prototype', src: `
+    expected: 'function(a, b,c) {return a + b * c;}'
+  },
+  {
+    name: 'Function.prototype has no .prototype',
+    src: `
     Function.prototype.hasOwnProperty('prototype');
     `,
-    expected: false },
-
-  { name: 'Function.prototype.toString applied to non-fucntion throws', src: `
+    expected: false
+  },
+  {
+    name: 'Function.prototype.toString applied to non-fucntion throws',
+    src: `
     try {
       Function.prototype.toString.apply({});
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Function.prototype.apply non-function throws', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Function.prototype.apply non-function throws',
+    src: `
     var o = {};
     o.apply = Function.prototype.apply;
     try {
@@ -1611,34 +1953,42 @@ module.exports = [
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Function.prototype.apply this', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Function.prototype.apply this',
+    src: `
     var o = {};
     function f() { return this; }
     f.apply(o, []) === o;
     `,
-    expected: true },
-
-  { name: 'Function.prototype.apply(..., undefined) or null', src: `
+    expected: true
+  },
+  {
+    name: 'Function.prototype.apply(..., undefined) or null',
+    src: `
     var n = 0;
     function f() { n += arguments.length; }
     f.apply(undefined, undefined);
     f.apply(undefined, null);
     n;
     `,
-    expected: 0 },
-
-  { name: 'Function.prototype.apply(..., non-object)', src: `
+    expected: 0
+  },
+  {
+    name: 'Function.prototype.apply(..., non-object)',
+    src: `
     try {
       (function() {}).apply(undefined, 'not an object');
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Function.prototype.apply(..., sparse)', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Function.prototype.apply(..., sparse)',
+    src: `
     (function(a, b, c) {
       if (!(1 in arguments)) {
         throw new Error('Argument 1 missing');
@@ -1646,23 +1996,29 @@ module.exports = [
       return a + c;
     }).apply(undefined, [1, , 3]);
     `,
-    expected: 4 },
-
-  { name: 'Function.prototype.apply(..., array-like)', src: `
+    expected: 4
+  },
+  {
+    name: 'Function.prototype.apply(..., array-like)',
+    src: `
     (function(a, b, c) {
       return a + b + c;
     }).apply(undefined, {0: 1, 1: 2, 2: 3, length: 3});
     `,
-    expected: 6 },
-
-  { name: 'Function.prototype.apply(..., non-array-like)', src: `
+    expected: 6
+  },
+  {
+    name: 'Function.prototype.apply(..., non-array-like)',
+    src: `
     (function(a, b, c) {
       return a + b + c;
     }).apply(undefined, {0: 1, 1: 2, 2: 4});
     `,
-    expected: NaN },  // Because undefined + undefined === NaN.
-
-  { name: 'Function.prototype.call non-function throws', src: `
+    expected: NaN
+  },  // Because undefined + undefined === NaN.
+  {
+    name: 'Function.prototype.call non-function throws',
+    src: `
     var o = {};
     o.call = Function.prototype.call;
     try {
@@ -1671,22 +2027,28 @@ module.exports = [
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Function.prototype.call this', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Function.prototype.call this',
+    src: `
     var o = {};
     function f() { return this; }
     f.call(o) === o;
     `,
-    expected: true },
-
-  { name: 'Function.prototype.call no args', src: `
+    expected: true
+  },
+  {
+    name: 'Function.prototype.call no args',
+    src: `
     function f() { return arguments.length; }
     f.call(undefined);
     `,
-    expected: 0 },
-
-  { name: 'Function.prototype.call', src: `
+    expected: 0
+  },
+  {
+    name: 'Function.prototype.call',
+    src: `
     (function(a, b, c) {
       if (!(1 in arguments)) {
         throw new Error('Argument 1 missing');
@@ -1694,9 +2056,11 @@ module.exports = [
       return a + c;
     }).call(undefined, 1, 2, 3);
     `,
-    expected: 4 },
-
-  { name: 'Function.prototype.bind non-function throws', src: `
+    expected: 4
+  },
+  {
+    name: 'Function.prototype.bind non-function throws',
+    src: `
     var o = {};
     o.bind = Function.prototype.bind;
     try {
@@ -1705,48 +2069,60 @@ module.exports = [
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Function.prototype.bind this', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Function.prototype.bind this',
+    src: `
     var o = {};
     function f() { return this; }
     f.bind(o)() === o;
     `,
-    expected: true },
-
-  { name: 'Function.prototype.bind no args', src: `
+    expected: true
+  },
+  {
+    name: 'Function.prototype.bind no args',
+    src: `
     function f() { return arguments.length; }
     f.bind(undefined)();
     `,
-    expected: 0 },
-
-  { name: 'Function.prototype.bind', src: `
+    expected: 0
+  },
+  {
+    name: 'Function.prototype.bind',
+    src: `
     var d = 4;
     (function(a, b, c) {
       return a + b + c + d;
     }).bind(undefined, 1).bind(undefined, 2)(3);
     `,
-    expected: 10 },
-
-  { name: 'Function.prototype.bind call BF', src: `
+    expected: 10
+  },
+  {
+    name: 'Function.prototype.bind call BF',
+    src: `
     var constructed;
     function Foo() {constructed = (this instanceof Foo)}
     var f = Foo.bind();
     f();
     constructed;
     `,
-    expected: false },
-
-  { name: 'Function.prototype.bind construct BF', src: `
+    expected: false
+  },
+  {
+    name: 'Function.prototype.bind construct BF',
+    src: `
     var constructed;
     function Foo() {constructed = (this instanceof Foo)}
     var f = Foo.bind();
     new f;
     constructed;
     `,
-    expected: true },
-
-  { name: 'Function.prototype.call.bind construct BF', src: `
+    expected: true
+  },
+  {
+    name: 'Function.prototype.call.bind construct BF',
+    src: `
     var invoked;
     function Foo() {invoked = true};
     var f = Foo.call.bind(Foo);
@@ -1756,10 +2132,12 @@ module.exports = [
       !invoked && e.name;
     }
     `,
-    expected: 'TypeError' },
-
+    expected: 'TypeError'
+  },
   // N.B.: tests of class constructor semantics unavoidably ES6.
-  { name: 'Function.prototype.bind class constructor w/o new', src: `
+  {
+    name: 'Function.prototype.bind class constructor w/o new',
+    src: `
     var f = WeakMap.bind();  // Should be O.K.
     try {
       f();
@@ -1767,237 +2145,313 @@ module.exports = [
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
+    expected: 'TypeError'
+  },
   // N.B.: tests of class constructor semantics unavoidably ES6.
-  { name: 'Function.protote.bind class constructor', src: `
+  {
+    name: 'Function.protote.bind class constructor',
+    src: `
     String(new (WeakMap.bind()));
     `,
-    expected: '[object WeakMap]' },
-
+    expected: '[object WeakMap]'
+  },
   /////////////////////////////////////////////////////////////////////////////
   // Array and Array.prototype
-
-  { name: 'new Array()NoArgs', src: `
+  {
+    name: 'new Array()NoArgs',
+    src: `
     var a = new Array;
     Array.isArray(a) && a.length;
     `,
-    expected: 0 },
-
-  { name: 'newArray(number)', src: `
+    expected: 0
+  },
+  {
+    name: 'newArray(number)',
+    src: `
     var a = new Array(42);
     Array.isArray(a) && !(0 in a) && !(41 in a) && a.length;
     `,
-    expected: 42 },
-
-  { name: 'new Array(non-number)', src: `
+    expected: 42
+  },
+  {
+    name: 'new Array(non-number)',
+    src: `
     var a = new Array('foo');
     Array.isArray(a) && a.length === 1 && a[0];
     `,
-    expected: 'foo' },
-
-  { name: 'new Array multiple args', src: `
+    expected: 'foo'
+  },
+  {
+    name: 'new Array multiple args',
+    src: `
     var a = new Array(1, 2, 3);
     Array.isArray(a) && a.length === 3 && String(a);
     `,
-    expected: '1,2,3' },
-
-  { name: 'Array.isArray Array.prototype', src: `
+    expected: '1,2,3'
+  },
+  {
+    name: 'Array.isArray Array.prototype',
+    src: `
     Array.isArray(Array.prototype);
     `,
-    expected: true },
-
-  { name: 'Array.isArray Array instance', src: `
+    expected: true
+  },
+  {
+    name: 'Array.isArray Array instance',
+    src: `
     Array.isArray(new Array);
     `,
-    expected: true },
-
-  { name: 'Array.isArray array literal', src: `
+    expected: true
+  },
+  {
+    name: 'Array.isArray array literal',
+    src: `
     Array.isArray([]);
     `,
-    expected: true },
-
-  { name: 'Array.isArray(array-like)', src: `
+    expected: true
+  },
+  {
+    name: 'Array.isArray(array-like)',
+    src: `
     Array.isArray({0: 'foo', 1: 'bar', length: 2});
     `,
-    expected: false },
-
-  { name: 'Array.prototype.concat()', src: `
+    expected: false
+  },
+  {
+    name: 'Array.prototype.concat()',
+    src: `
         var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
         var c = a.concat();
         a.length === 6 && c.length === 6 && c !== a && String(c);
     `,
-    expected: 'foo,bar,baz,,quux,quuux' },
-
-  { name: 'Array.prototype.concat(...)', src: `
+    expected: 'foo,bar,baz,,quux,quuux'
+  },
+  {
+    name: 'Array.prototype.concat(...)',
+    src: `
         var o = {0: 'quux', 1: 'quuux', length: 2};
         var c = [].concat(['foo', 'bar'], 'baz', undefined, o);
         c.length === 5 && '3' in c && c[3] === undefined && String(c);
     `,
-    expected: 'foo,bar,baz,,[object Object]' },
-
-  { name: 'Array.prototype.concat.call(object, ...)', src: `
+    expected: 'foo,bar,baz,,[object Object]'
+  },
+  {
+    name: 'Array.prototype.concat.call(object, ...)',
+    src: `
         var o = {0: 'foo', 1: 'bar', length: 2};
         var c = Array.prototype.concat.call(o, 'baz', [, 'quux', 'quuux']);
         c.length === 5 && String(c);
     `,
-    expected: '[object Object],baz,,quux,quuux' },
-
-  { name: 'Array.prototype.includes', src: `
+    expected: '[object Object],baz,,quux,quuux'
+  },
+  {
+    name: 'Array.prototype.includes',
+    src: `
     [1, 2, 3, 2, 1].includes(2);
     `,
-    expected: true },
-
-  { name: 'Array.prototype.includes not found', src: `
+    expected: true
+  },
+  {
+    name: 'Array.prototype.includes not found',
+    src: `
     [1, 2, 3, 2, 1].includes(4);
     `,
-    expected: false },
-
-  { name: 'Array.prototype.includes(..., +)', src: `
+    expected: false
+  },
+  {
+    name: 'Array.prototype.includes(..., +)',
+    src: `
     [1, 2, 3, 2, 1].includes(2, 2);
     `,
-    expected: true },
-
-  { name: 'Array.prototype.includes(..., -)', src: `
+    expected: true
+  },
+  {
+    name: 'Array.prototype.includes(..., -)',
+    src: `
     [1, 2, 3, 2, 1].includes(1, -3);
     `,
-    expected: true },
-
-  { name: 'Array.prototype.includes NaN', src: `
+    expected: true
+  },
+  {
+    name: 'Array.prototype.includes NaN',
+    src: `
     ['x', NaN, 'y'].includes(NaN);
     `,
-    expected: true },
-
-  { name: 'Array.prototype.includes.call(array-like, ...)', src: `
+    expected: true
+  },
+  {
+    name: 'Array.prototype.includes.call(array-like, ...)',
+    src: `
     var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
     Array.prototype.includes.call(o, 2);
     `,
-    expected: true },
-
-  { name: 'Array.prototype.indexOf', src: `
+    expected: true
+  },
+  {
+    name: 'Array.prototype.indexOf',
+    src: `
     [1, 2, 3, 2, 1].indexOf(2);
     `,
-    expected: 1 },
-
-  { name: 'Array.prototype.indexOf not found', src: `
+    expected: 1
+  },
+  {
+    name: 'Array.prototype.indexOf not found',
+    src: `
     [1, 2, 3, 2, 1].indexOf(4);
     `,
-    expected: -1 },
-
-  { name: 'Array.prototype.indexOf(..., +)', src: `
+    expected: -1
+  },
+  {
+    name: 'Array.prototype.indexOf(..., +)',
+    src: `
     [1, 2, 3, 2, 1].indexOf(2, 2);
     `,
-    expected: 3 },
-
-  { name: 'Array.prototype.indexOf(..., -)', src: `
+    expected: 3
+  },
+  {
+    name: 'Array.prototype.indexOf(..., -)',
+    src: `
     [1, 2, 3, 2, 1].indexOf(1, -3);
     `,
-    expected: 4 },
-
-  { name: 'Array.prototype.indexOf NaN', src: `
+    expected: 4
+  },
+  {
+    name: 'Array.prototype.indexOf NaN',
+    src: `
     ['x', NaN, 'y'].indexOf(NaN);
     `,
-    expected: -1 },
-
-  { name: 'Array.prototype.indexOf.call(array-like, ...)', src: `
+    expected: -1
+  },
+  {
+    name: 'Array.prototype.indexOf.call(array-like, ...)',
+    src: `
     var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
     Array.prototype.indexOf.call(o, 2);
     `,
-    expected: 1 },
-
-  { name: 'Array.prototype.join', src: `
+    expected: 1
+  },
+  {
+    name: 'Array.prototype.join',
+    src: `
     [1, 2, 3].join('-');
     `,
-    expected: '1-2-3' },
-
-  { name: 'Array.prototype.join cycle detection', src: `
+    expected: '1-2-3'
+  },
+  {
+    name: 'Array.prototype.join cycle detection',
+    src: `
     var a = [1, , 3];
     a[1] = a;
     a.join('-');
     "Didn't crash!";
     `,
-    expected: "Didn't crash!" },
-
-  { name: 'Array.prototype.lastIndexOf', src: `
+    expected: 'Didn\'t crash!'
+  },
+  {
+    name: 'Array.prototype.lastIndexOf',
+    src: `
     [1, 2, 3, 2, 1].lastIndexOf(2);
     `,
-    expected: 3 },
-
-  { name: 'Array.prototype.lastIndexOf not found', src: `
+    expected: 3
+  },
+  {
+    name: 'Array.prototype.lastIndexOf not found',
+    src: `
     [1, 2, 3, 2, 1].lastIndexOf(4);
     `,
-    expected: -1 },
-
-  { name: 'Array.prototype.lastIndexOf(..., +)', src: `
+    expected: -1
+  },
+  {
+    name: 'Array.prototype.lastIndexOf(..., +)',
+    src: `
     [1, 2, 3, 2, 1].lastIndexOf(2, 2);
     `,
-    expected: 1 },
-
-  { name: 'Array.prototype.lastIndexOf(..., -)', src: `
+    expected: 1
+  },
+  {
+    name: 'Array.prototype.lastIndexOf(..., -)',
+    src: `
     [1, 2, 3, 2, 1].lastIndexOf(1, -3);
     `,
-    expected: 0 },
-
-  { name: 'Array.prototype.lastIndexOf.call(array-like, ...)', src: `
+    expected: 0
+  },
+  {
+    name: 'Array.prototype.lastIndexOf.call(array-like, ...)',
+    src: `
     var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
     Array.prototype.lastIndexOf.call(o, 2);
     `,
-    expected: 3 },
-
-  { name: 'Array.prototype.pop', src: `
+    expected: 3
+  },
+  {
+    name: 'Array.prototype.pop',
+    src: `
         var a = ['foo', 'bar', 'baz'];
         var r = a.pop();
         a.length === 2 && r;
     `,
-    expected: 'baz' },
-
-  { name: 'Array.prototype.pop empty array', src: `
+    expected: 'baz'
+  },
+  {
+    name: 'Array.prototype.pop empty array',
+    src: `
         var a = [];
         var r = a.pop();
         a.length === 0 && r;
     `,
-    expected: undefined },
-
-  { name: 'Array.prototype.pop.apply(array-like)', src: `
+    expected: undefined
+  },
+  {
+    name: 'Array.prototype.pop.apply(array-like)',
+    src: `
         var o = {0: 'foo', 1: 'bar', 2: 'baz', length: 3};
         var r = Array.prototype.pop.apply(o);
         o.length === 2 && r;
     `,
-    expected: 'baz' },
-
-  { name: 'Array.prototype.pop.apply(empty array-like)', src: `
+    expected: 'baz'
+  },
+  {
+    name: 'Array.prototype.pop.apply(empty array-like)',
+    src: `
         var o = {length: 0};
         var r = Array.prototype.pop.apply(o);
         o.length === 0 && r;
     `,
-    expected: undefined },
-
-  { name: 'Array.prototype.pop.apply(huge array-like)', src: `
+    expected: undefined
+  },
+  {
+    name: 'Array.prototype.pop.apply(huge array-like)',
+    src: `
         var o = {5000000000000000: 'foo',
                  5000000000000001: 'quux',
                  length: 5000000000000002};
         var r = Array.prototype.pop.apply(o);
         o.length === 5000000000000001 && o[5000000000000000] === 'foo' && r;
     `,
-    expected: 'quux' },
-
-  { name: 'Array.prototype.push', src: `
+    expected: 'quux'
+  },
+  {
+    name: 'Array.prototype.push',
+    src: `
         var a = [];
         a.push('foo') === 1 && a.push('bar') === 2 &&
             a.length === 2 && a[0] === 'foo' && a[1] === 'bar';
     `,
-    expected: true },
-
-  { name: 'Array.prototype.push.call(array-like, ...)', src: `
+    expected: true
+  },
+  {
+    name: 'Array.prototype.push.call(array-like, ...)',
+    src: `
         var o = {length: 0};
         Array.prototype.push.call(o, 'foo') === 1 &&
             Array.prototype.push.call(o, 'bar') === 2 &&
             o.length === 2 && o[0] === 'foo' && o[1] === 'bar';
-
     `,
-    expected: true },
-
-  { name: 'Array.prototype.push.call(huge array-like, ...)', src: `
+    expected: true
+  },
+  {
+    name: 'Array.prototype.push.call(huge array-like, ...)',
+    src: `
         var o = {length: 5000000000000000};
         var o = {length: 5000000000000000};
         Array.prototype.push.call(o, 'foo') === 5000000000000001 &&
@@ -2005,75 +2459,97 @@ module.exports = [
             o[5000000000000000] === 'foo' && o[5000000000000001] === 'bar' &&
             o.length === 5000000000000002
     `,
-    expected: true },
-
-  { name: 'Array.prototype.reverse odd-length', src: `
+    expected: true
+  },
+  {
+    name: 'Array.prototype.reverse odd-length',
+    src: `
         var a = [1, 2, 3];
         a.reverse() === a && a.length === 3 && String(a);
     `,
-    expected: '3,2,1' },
-
-  { name: 'Array.prototype.reverse even-length', src: `
+    expected: '3,2,1'
+  },
+  {
+    name: 'Array.prototype.reverse even-length',
+    src: `
         var a = [1, 2, , 4];
         a.reverse() === a && a.length === 4 && String(a);
     `,
-    expected: '4,,2,1' },
-
-  { name: 'Array.prototype.reverse empty', src: `
+    expected: '4,,2,1'
+  },
+  {
+    name: 'Array.prototype.reverse empty',
+    src: `
         var a = [];
         a.reverse() === a && a.length;
     `,
-    expected: 0 },
-
-  { name: 'Array.prototype.reverse.call(odd-length array-like)', src: `
+    expected: 0
+  },
+  {
+    name: 'Array.prototype.reverse.call(odd-length array-like)',
+    src: `
         var o = {0: 1, 1: 2, 2: 3, length: 3};
         Array.prototype.reverse.call(o) === o && o.length === 3 &&
             Array.prototype.slice.apply(o).toString();
     `,
-    expected: '3,2,1' },
-
-  { name: 'Array.prototype.reverse.call(even-length array-like)', src: `
+    expected: '3,2,1'
+  },
+  {
+    name: 'Array.prototype.reverse.call(even-length array-like)',
+    src: `
         var o = {0: 1, 1: 2, 3: 4, length: 4};
         Array.prototype.reverse.call(o) === o && o.length === 4 &&
             Array.prototype.slice.apply(o).toString();
     `,
-    expected: '4,,2,1' },
-
-  { name: 'Array.prototype.reverse.call(empty array-like)', src: `
+    expected: '4,,2,1'
+  },
+  {
+    name: 'Array.prototype.reverse.call(empty array-like)',
+    src: `
         var o = {length: 0};
         Array.prototype.reverse.call(o) === o && o.length;
     `,
-    expected: 0 },
-
-  { name: 'Array.prototype.shift', src: `
+    expected: 0
+  },
+  {
+    name: 'Array.prototype.shift',
+    src: `
         var a = ['foo', 'bar', 'baz'];
         var r = a.shift();
         a.length === 2 && a[0] === 'bar' && a[1] === 'baz' && r;
     `,
-    expected: 'foo' },
-
-  { name: 'Array.prototype.shift empty array', src: `
+    expected: 'foo'
+  },
+  {
+    name: 'Array.prototype.shift empty array',
+    src: `
         var a = [];
         var r = a.shift();
         a.length === 0 && r;
     `,
-    expected: undefined },
-
-  { name: 'Array.prototype.shift.apply(array-like)', src: `
+    expected: undefined
+  },
+  {
+    name: 'Array.prototype.shift.apply(array-like)',
+    src: `
         var o = {0: 'foo', 1: 'bar', 2: 'baz', length: 3};
         var r = Array.prototype.shift.apply(o);
         o.length === 2 && o[0] === 'bar' && o[1] === 'baz' && r;
     `,
-    expected: 'foo' },
-
-  { name: 'Array.prototype.shift.apply(empty array-like)', src: `
+    expected: 'foo'
+  },
+  {
+    name: 'Array.prototype.shift.apply(empty array-like)',
+    src: `
         var o = {length: 0};
         var r = Array.prototype.shift.apply(o);
         o.length === 0 && r;
     `,
-    expected: undefined },
-
-  { name: 'Array.prototype.shift.apply(huge array-like)', src: `
+    expected: undefined
+  },
+  {
+    name: 'Array.prototype.shift.apply(huge array-like)',
+    src: `
         var o = {5000000000000000: 'foo',
                  5000000000000001: 'quux',
                  length: 5000000000000002};
@@ -2081,37 +2557,47 @@ module.exports = [
         o.length === 5000000000000001 && o[5000000000000000] === 'quux' && r;
     `,
     // SKIP until more efficient shift implementation available.
-    /* expected: 'foo' */ },
-
-  { name: 'Array.prototype.slice()', src: `
+    /* expected: 'foo' */
+  },
+  {
+    name: 'Array.prototype.slice()',
+    src: `
         var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
         var s = a.slice();
         a.length === 6 && s.length === 6 && String(s);
     `,
-    expected: 'foo,bar,baz,,quux,quuux' },
-
-  { name: 'Array.prototype.slice(-)', src: `
+    expected: 'foo,bar,baz,,quux,quuux'
+  },
+  {
+    name: 'Array.prototype.slice(-)',
+    src: `
         var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
         var s = a.slice(-2);
         a.length === 6 && s.length === 2 && String(s);
     `,
-    expected: 'quux,quuux' },
-
-  { name: 'Array.prototype.slice(+, +)', src: `
+    expected: 'quux,quuux'
+  },
+  {
+    name: 'Array.prototype.slice(+, +)',
+    src: `
         var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
         var s = a.slice(1, 4);
         a.length === 6 && s.length === 3 && !('2' in s) && String(s);
     `,
-    expected: 'bar,baz,' },
-
-  { name: 'Array.prototype.slice(+, -)', src: `
+    expected: 'bar,baz,'
+  },
+  {
+    name: 'Array.prototype.slice(+, -)',
+    src: `
         var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
         var s = a.slice(1, -2);
         a.length === 6 && s.length === 3 && !('2' in s) && String(s);
     `,
-    expected: 'bar,baz,' },
-
-  { name: 'Array.prototype.slice.call(array-like, -, +)', src: `
+    expected: 'bar,baz,'
+  },
+  {
+    name: 'Array.prototype.slice.call(array-like, -, +)',
+    src: `
         var o = {
           0: 'foo', 1: 'bar', 2: 'baz', 4: 'quux', 5: 'quuux', length: 6
         };
@@ -2119,9 +2605,11 @@ module.exports = [
         !Array.isArray(o) && o.length === 6 &&
             Array.isArray(s) && s.length === 3 && !('2' in s) && String(s);
     `,
-    expected: 'bar,baz,' },
-
-  { name: 'Array.prototype.slice.call(huge array-like, -, -)', src: `
+    expected: 'bar,baz,'
+  },
+  {
+    name: 'Array.prototype.slice.call(huge array-like, -, -)',
+    src: `
         var o = {
           5000000000000000: 'foo', 5000000000000001: 'bar',
           5000000000000002: 'baz', 5000000000000004: 'quux',
@@ -2131,25 +2619,33 @@ module.exports = [
         !Array.isArray(o) && o.length === 5000000000000006 &&
             Array.isArray(s) && s.length === 3 && !('2' in s) && String(s);
     `,
-    expected: 'bar,baz,' },
-
-  { name: 'Array.prototype.sort()', src: `
+    expected: 'bar,baz,'
+  },
+  {
+    name: 'Array.prototype.sort()',
+    src: `
     [5, 2, 3, 1, 4].sort().join();  // Sorts ASCIIbetically.
     `,
-    expected: '1,2,3,4,5' },
-
-  { name: 'Array.prototype.sort() compaction', src: `
+    expected: '1,2,3,4,5'
+  },
+  {
+    name: 'Array.prototype.sort() compaction',
+    src: `
     ['z', undefined, 10, , 'aa', null, 'a', 5, NaN, , 1].sort()
         .map(String).join();
     `,
-    expected: '1,10,5,NaN,a,aa,null,z,undefined,,' },
-
-  { name: 'Array.prototype.sort(comparefn)', src: `
+    expected: '1,10,5,NaN,a,aa,null,z,undefined,,'
+  },
+  {
+    name: 'Array.prototype.sort(comparefn)',
+    src: `
     [99, 9, 10, 11, 1, 0, 5].sort(function(a, b) {return a - b;}).join();
     `,
-    expected: '0,1,5,9,10,11,99' },
-
-  { name: 'Array.prototype.sort(comparefn) compaction', src: `
+    expected: '0,1,5,9,10,11,99'
+  },
+  {
+    name: 'Array.prototype.sort(comparefn) compaction',
+    src: `
     ['z', undefined, 10, , 'aa', null, 'a', 5, NaN, , 1].sort(
         function(a, b) {
           // Try to put undefineds first - should not succeed.
@@ -2163,30 +2659,38 @@ module.exports = [
           return 0;
         }).map(String).join();
     `,
-    expected: 'z,null,aa,a,NaN,5,10,1,undefined,,' },
-
-  { name: 'Array.prototype.splice()', src: `
+    expected: 'z,null,aa,a,NaN,5,10,1,undefined,,'
+  },
+  {
+    name: 'Array.prototype.splice()',
+    src: `
         var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
         var s = a.splice();
         a.length === 6 && s.length === 0 && String(a) + ':' + String(s);
     `,
-    expected: 'foo,bar,baz,,quux,quuux:' },
-
-  { name: 'Array.prototype.splice(-)', src: `
+    expected: 'foo,bar,baz,,quux,quuux:'
+  },
+  {
+    name: 'Array.prototype.splice(-)',
+    src: `
         var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
         var s = a.splice(-2);
         a.length === 4 && s.length === 2 && String(a) + ':' + String(s);
     `,
-    expected: 'foo,bar,baz,:quux,quuux' },
-
-  { name: 'Array.prototype.splice(+, +, ...)', src: `
+    expected: 'foo,bar,baz,:quux,quuux'
+  },
+  {
+    name: 'Array.prototype.splice(+, +, ...)',
+    src: `
         var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
         var s = a.splice(1, 3, 'bletch');
         a.length === 4 && s.length === 3 && String(a) + ':' + String(s);
     `,
-    expected: 'foo,bletch,quux,quuux:bar,baz,' },
-
-  { name: 'Array.prototype.splice.call(array-like, 0, large, ...)', src: `
+    expected: 'foo,bletch,quux,quuux:bar,baz,'
+  },
+  {
+    name: 'Array.prototype.splice.call(array-like, 0, large, ...)',
+    src: `
         var o = {
           0: 'foo', 1: 'bar', 2: 'baz', 4: 'quux', 5: 'quuux', length: 6
         };
@@ -2195,9 +2699,11 @@ module.exports = [
         o[0] === 'bletch' &&
         Array.isArray(s) && s.length === 6 && !('3' in s) && String(s);
     `,
-    expected: 'foo,bar,baz,,quux,quuux' },
-
-  { name: 'Array.prototype.splice.call(huge array-like, -, -, many...)', src: `
+    expected: 'foo,bar,baz,,quux,quuux'
+  },
+  {
+    name: 'Array.prototype.splice.call(huge array-like, -, -, many...)',
+    src: `
         var o = {
           5000000000000000: 'foo', 5000000000000001: 'bar',
           5000000000000002: 'baz', 5000000000000004: 'quux',
@@ -2209,45 +2715,56 @@ module.exports = [
             o[5000000000000006] === 'quux' && o[5000000000000007] === 'quuux' &&
             Array.isArray(s) && s.length === 0;
     `,
-    expected: true },
-
-  { name: 'Array.prototype.toString cycle detection', src: `
+    expected: true
+  },
+  {
+    name: 'Array.prototype.toString cycle detection',
+    src: `
     var a = [1, , 3];
     a[1] = a;
     a.toString();
     "Didn't crash!";
     `,
-    expected: "Didn't crash!" },
-
-  { name: 'Array.prototype.toString.call(obj-w/join)', src: `
+    expected: 'Didn\'t crash!'
+  },
+  {
+    name: 'Array.prototype.toString.call(obj-w/join)',
+    src: `
     var o = {join: function() {return 'OK';}};
     Array.prototype.toString.apply(o);
     `,
-    expected: 'OK' },
-
-  { name: 'Array.prototype.toString.call(array-like)', src: `
+    expected: 'OK'
+  },
+  {
+    name: 'Array.prototype.toString.call(array-like)',
+    src: `
     var o = {0: 'foo', 1: 'bar', length: 2};
     Array.prototype.toString.apply(o);
     `,
-    expected: '[object Object]' },
-
-  { name: 'Array.prototype.unshift', src: `
+    expected: '[object Object]'
+  },
+  {
+    name: 'Array.prototype.unshift',
+    src: `
         var a = [];
         a.unshift('foo') === 1 && a.unshift('bar') === 2 &&
             a.length === 2 && a[0] === 'bar' && a[1] === 'foo';
     `,
-    expected: true },
-
-  { name: 'Array.prototype.unshift.call(array-like, ...)', src: `
+    expected: true
+  },
+  {
+    name: 'Array.prototype.unshift.call(array-like, ...)',
+    src: `
         var o = {length: 0};
         Array.prototype.unshift.call(o, 'foo') === 1 &&
             Array.prototype.unshift.call(o, 'bar') === 2 &&
             o.length === 2 && o[0] === 'bar' && o[1] === 'foo';
-
     `,
-    expected: true },
-
-  { name: 'Array.prototype.unshift.call(huge array-like, ...)', src: `
+    expected: true
+  },
+  {
+    name: 'Array.prototype.unshift.call(huge array-like, ...)',
+    src: `
         var o = {length: 5000000000000000};
         var o = {length: 5000000000000000};
         Array.prototype.unshift.call(o, 'foo') === 5000000000000001 &&
@@ -2256,11 +2773,13 @@ module.exports = [
             o.length === 5000000000000002
     `,
     // SKIP until more efficient unshift implementation available.
-    /* expected: true */ },
-
+    /* expected: true */
+  },
   /////////////////////////////////////////////////////////////////////////////
   // Boolean and Boolean.prototype
-  { name: 'Boolean', src: `
+  {
+    name: 'Boolean',
+    src: `
     var tests = [
       [undefined, false],
       [null, false],
@@ -2283,58 +2802,72 @@ module.exports = [
     }
     (ok === tests.length) ? 'pass' : 'fail';
     `,
-    expected: 'pass' },
-
-  { name: 'Boolean.prototype.toString()', src: `
+    expected: 'pass'
+  },
+  {
+    name: 'Boolean.prototype.toString()',
+    src: `
     Boolean.prototype.toString();
     `,
-    expected: 'false' },
-
-  { name: 'Boolean.prototype.toString.call(true)', src: `
+    expected: 'false'
+  },
+  {
+    name: 'Boolean.prototype.toString.call(true)',
+    src: `
     Boolean.prototype.toString.call(true);
     `,
-    expected: 'true' },
-
-  { name: 'Boolean.prototype.toString.call(false)', src: `
+    expected: 'true'
+  },
+  {
+    name: 'Boolean.prototype.toString.call(false)',
+    src: `
     Boolean.prototype.toString.call(false);
     `,
-    expected: 'false' },
-
-  { name: 'Boolean.prototype.toString.call non-Boolean object', src: `
+    expected: 'false'
+  },
+  {
+    name: 'Boolean.prototype.toString.call non-Boolean object',
+    src: `
     try {
       Boolean.prototype.toString.call({});
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Boolean.prototype.valueOf()', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Boolean.prototype.valueOf()',
+    src: `
     Boolean.prototype.valueOf();
     `,
-    expected: false },
-
-  { name: 'Boolean.prototype.valueOf.call primitive', src: `
+    expected: false
+  },
+  {
+    name: 'Boolean.prototype.valueOf.call primitive',
+    src: `
     Boolean.prototype.valueOf.call(true) &&
         !Boolean.prototype.valueOf.call(false);
     `,
-    expected: true },
-
-  { name: 'Boolean.prototype.valueOf.call non-Boolean object', src: `
+    expected: true
+  },
+  {
+    name: 'Boolean.prototype.valueOf.call non-Boolean object',
+    src: `
     try {
       Boolean.prototype.valueOf.call({});
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
+    expected: 'TypeError'
+  },
   /////////////////////////////////////////////////////////////////////////////
   // Number and Number.prototype
-
-  { name: 'Number()', src: 'Number();', expected: 0 },
-
-  { name: 'Number', src: `
+  {name: 'Number()', src: 'Number();', expected: 0},
+  {
+    name: 'Number',
+    src: `
     var tests = [
       [undefined, NaN],
       [null, 0],
@@ -2356,59 +2889,73 @@ module.exports = [
     }
     (ok === tests.length) ? 'pass' : 'fail';
     `,
-    expected: 'pass' },
-
-  { name: 'Number.MAX_SAFE_INTEGER', src: `
+    expected: 'pass'
+  },
+  {
+    name: 'Number.MAX_SAFE_INTEGER',
+    src: `
     Number.MAX_SAFE_INTEGER + 1 === Math.pow(2, 53) &&
         Number.isSafeInteger(Number.MAX_SAFE_INTEGER) &&
         !Number.isSafeInteger(Number.MAX_SAFE_INTEGER + 1);
     `,
-    expected: true },
-
-  { name: 'Number.prototype.toString()', src: `
+    expected: true
+  },
+  {
+    name: 'Number.prototype.toString()',
+    src: `
     Number.prototype.toString();
     `,
-    expected: '0' },
-
-  { name: 'Number.prototype.toString.call primitive', src: `
+    expected: '0'
+  },
+  {
+    name: 'Number.prototype.toString.call primitive',
+    src: `
     Number.prototype.toString.call(84);
     `,
-    expected: '84' },
-
-  { name: 'Number.prototype.toString.call non-Number object', src: `
+    expected: '84'
+  },
+  {
+    name: 'Number.prototype.toString.call non-Number object',
+    src: `
     try {
       Number.prototype.toString.call({});
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'Number.prototype.valueOf()', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'Number.prototype.valueOf()',
+    src: `
     Number.prototype.valueOf();
     `,
-    expected: 0 },
-
-  { name: 'Number.prototype.valueOf.call primitive', src: `
+    expected: 0
+  },
+  {
+    name: 'Number.prototype.valueOf.call primitive',
+    src: `
     Number.prototype.valueOf.call(85);
     `,
-    expected: 85 },
-
-  { name: 'Number.prototype.valueOf.call non-Number object', src: `
+    expected: 85
+  },
+  {
+    name: 'Number.prototype.valueOf.call non-Number object',
+    src: `
     try {
       Number.prototype.valueOf.call({});
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
+    expected: 'TypeError'
+  },
   /////////////////////////////////////////////////////////////////////////////
   // String and String.prototype
-
-  { name: 'String()', src: 'String();', expected: '' },
-
-  { name: 'String', src: `
+  {name: 'String()', src: 'String();', expected: ''},
+  {
+    name: 'String',
+    src: `
     var tests = [
       [undefined, 'undefined'],
       [null, 'null'],
@@ -2430,23 +2977,29 @@ module.exports = [
     }
     (ok === tests.length) ? 'pass' : 'fail';
     `,
-    expected: 'pass' },
-
-  { name: 'String calls valueOf', src: `
+    expected: 'pass'
+  },
+  {
+    name: 'String calls valueOf',
+    src: `
         var o = Object.create(null);
         o.valueOf = function() {return 'OK';};
         String(o);
     `,
-    expected: 'OK' },
-
-  { name: 'String calling valueOf returns string', src: `
+    expected: 'OK'
+  },
+  {
+    name: 'String calling valueOf returns string',
+    src: `
         var o = Object.create(null);
         o.valueOf = function() {return 42;};
         String(o);
     `,
-    expected: '42' },
-
-  { name: 'String calling valueOf throws', src: `
+    expected: '42'
+  },
+  {
+    name: 'String calling valueOf throws',
+    src: `
         var o = Object.create(null);
         o.valueOf = function() {return {};};
         try {
@@ -2455,24 +3008,30 @@ module.exports = [
           e.name;
         }
     `,
-    expected: 'TypeError' },
-
-  { name: 'String calls toString', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'String calls toString',
+    src: `
         var o = Object.create(null);
         o.valueOf = function() {return 'Whoops: called valueOf';};
         o.toString = function() {return 'OK';};
         String(o);
     `,
-    expected: 'OK' },
-
-  { name: 'String calling toString returns string', src: `
+    expected: 'OK'
+  },
+  {
+    name: 'String calling toString returns string',
+    src: `
         var o = Object.create(null);
         o.valueOf = function() {return 42;};
         String(o);
     `,
-    expected: '42' },
-
-  { name: 'String calling toString throws', src: `
+    expected: '42'
+  },
+  {
+    name: 'String calling toString throws',
+    src: `
         var o = Object.create(null);
         o.valueOf = function() {return {};};
         o.toString = function() {return {};};
@@ -2482,112 +3041,139 @@ module.exports = [
           e.name;
         }
     `,
-    expected: 'TypeError' },
-
-  { name: 'String.prototype.length',
+    expected: 'TypeError'
+  },
+  {
+    name: 'String.prototype.length',
     src: `String.prototype.length;`,
-    expected: 0 },
-
-  { name: 'String.prototype.replace(string, string)',
+    expected: 0
+  },
+  {
+    name: 'String.prototype.replace(string, string)',
     src: `'xxxx'.replace('xx', 'y');`,
-    expected: 'yxx' },
-
-  { name: 'String.prototype.replace(regexp, string)',
+    expected: 'yxx'
+  },
+  {
+    name: 'String.prototype.replace(regexp, string)',
     src: `'xxxx'.replace(/(X)\\1/ig, 'y');`,
-    expected: 'yy' },
-
-  { name: 'String.prototype.replace(string, function)', src: `
+    expected: 'yy'
+  },
+  {
+    name: 'String.prototype.replace(string, function)',
+    src: `
     'xxxx'.replace('xx', function() {
          return '[' + Array.prototype.join.apply(arguments) + ']';
     });
     `,
-    expected: '[xx,0,xxxx]xx' },
-
-  { name: 'String.prototype.replace(regexp, function)', src: `
+    expected: '[xx,0,xxxx]xx'
+  },
+  {
+    name: 'String.prototype.replace(regexp, function)',
+    src: `
     'xxxx'.replace(/(X)\\1/ig, function() {
          return '[' + Array.prototype.join.apply(arguments) + ']';
     });
     `,
-    expected: '[xx,x,0,xxxx][xx,x,2,xxxx]' },
-
-  { name: 'String.prototype.search(string) not found',
+    expected: '[xx,x,0,xxxx][xx,x,2,xxxx]'
+  },
+  {
+    name: 'String.prototype.search(string) not found',
     src: `'hello'.search('H')`,
-    expected: -1 },
-
-  { name: 'String.prototype.search(string) found',
+    expected: -1
+  },
+  {
+    name: 'String.prototype.search(string) found',
     src: `'hello'.search('ll')`,
-    expected: 2 },
-
-  { name: 'String.prototype.search(regexp) not found',
+    expected: 2
+  },
+  {
+    name: 'String.prototype.search(regexp) not found',
     src: `'hello'.search(/H/)`,
-    expected: -1 },
-
-  { name: 'String.prototype.search(regexp) found',
+    expected: -1
+  },
+  {
+    name: 'String.prototype.search(regexp) found',
     src: `'hello'.search(/(.)\\1/)`,
-    expected: 2 },
-
-  { name: 'String.prototype.toString()', src: `
+    expected: 2
+  },
+  {
+    name: 'String.prototype.toString()',
+    src: `
     String.prototype.toString();
     `,
-    expected: '' },
-
-  { name: 'String.prototype.toString.call primitive', src: `
+    expected: ''
+  },
+  {
+    name: 'String.prototype.toString.call primitive',
+    src: `
     String.prototype.toString.call('a string');
     `,
-    expected: 'a string' },
-
-  { name: 'String.prototype.toString.call non-String object', src: `
+    expected: 'a string'
+  },
+  {
+    name: 'String.prototype.toString.call non-String object',
+    src: `
     try {
       String.prototype.toString.call({});
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
-  { name: 'String.prototype.valueOf()', src: `
+    expected: 'TypeError'
+  },
+  {
+    name: 'String.prototype.valueOf()',
+    src: `
     String.prototype.valueOf();
     `,
-    expected: '' },
-
-  { name: 'String.prototype.valueOf.call primitive', src: `
+    expected: ''
+  },
+  {
+    name: 'String.prototype.valueOf.call primitive',
+    src: `
     String.prototype.valueOf.call('a string');
     `,
-    expected: 'a string' },
-
-  { name: 'String.prototype.valueOf.call non-String object', src: `
+    expected: 'a string'
+  },
+  {
+    name: 'String.prototype.valueOf.call non-String object',
+    src: `
     try {
       String.prototype.valueOf.call({});
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
+    expected: 'TypeError'
+  },
   /////////////////////////////////////////////////////////////////////////////
   // RegExp
-
-  { name: 'RegExp.prototype.test.apply(non-regexp) throws', src: `
+  {
+    name: 'RegExp.prototype.test.apply(non-regexp) throws',
+    src: `
     try {
       /foo/.test.apply({}, ['foo']);
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
+    expected: 'TypeError'
+  },
   /////////////////////////////////////////////////////////////////////////////
   // Error and Error.prototype (and all the other native error types too)
-
-  { name: 'new Error has .stack', src: `
+  {
+    name: 'new Error has .stack',
+    src: `
     // Use eval to make parsing .stack easier.
     var e = eval('new Error;');
     var lines = e.stack.split('\\n');
     lines[0].trim();
     `,
-    expected: 'at "new Error;" 1:1' },
-
-  { name: 'thrown Error has .stack', src: `
+    expected: 'at "new Error;" 1:1'
+  },
+  {
+    name: 'thrown Error has .stack',
+    src: `
     try {
       (function buggy() {1 instanceof 2;})();
     } catch (e) {
@@ -2595,18 +3181,22 @@ module.exports = [
     }
     lines[0].trim();
     `,
-    expected: 'at buggy 1:19' },
-
-  { name: 'Error .stack correctly reports anonymous function', src: `
+    expected: 'at buggy 1:19'
+  },
+  {
+    name: 'Error .stack correctly reports anonymous function',
+    src: `
     // Use eval to make parsing .stack easier.
     var e = eval('(function() {return new Error;})()');
     var lines = e.stack.split('\\n');
     lines[0].trim();
     `,
-    expected: 'at anonymous function 1:20' },
-
+    expected: 'at anonymous function 1:20'
+  },
   // Bug #241.
-  { name: 'Error .stack correctly blames MemberExpression', src: `
+  {
+    name: 'Error .stack correctly blames MemberExpression',
+    src: `
     function foo() {
       switch (1) {
         case 1:
@@ -2620,9 +3210,11 @@ module.exports = [
     }
     lines[0].trim();
     `,
-    expected: 'at foo 4:18' },
-
-  { name: 'Error .stack correctly blames Identifier', src: `
+    expected: 'at foo 4:18'
+  },
+  {
+    name: 'Error .stack correctly blames Identifier',
+    src: `
     function foo() {
       return undefinedVariable;
     }
@@ -2633,71 +3225,90 @@ module.exports = [
     }
     lines[0].trim();
     `,
-    expected: 'at foo 2:14' },
-
+    expected: 'at foo 2:14'
+  },
   /////////////////////////////////////////////////////////////////////////////
   // JSON
-
-  { name: 'JSON.stringify basic', src: `
+  {
+    name: 'JSON.stringify basic',
+    src: `
     JSON.stringify({
         string: 'foo', number: 42, true: true, false: false, null: null,
         object: { obj: {}, arr: [] }, array: [{}, []] });
     `,
     expected: '{"string":"foo","number":42,"true":true,"false":false,' +
-        '"null":null,"object":{"obj":{},"arr":[]},"array":[{},[]]}' },
-
-  { name: 'JSON.stringify(function(){})', src: `
+        '"null":null,"object":{"obj":{},"arr":[]},"array":[{},[]]}'
+  },
+  {
+    name: 'JSON.stringify(function(){})',
+    src: `
     JSON.stringify(function(){});
     `,
-    expected: undefined },
-
-  { name: 'JSON.stringify([function(){}])', src: `
+    expected: undefined
+  },
+  {
+    name: 'JSON.stringify([function(){}])',
+    src: `
     JSON.stringify([function(){}]);
     `,
-    expected: "[null]" },
-
-  { name: 'JSON.stringify({f: function(){}})', src: `
+    expected: '[null]'
+  },
+  {
+    name: 'JSON.stringify({f: function(){}})',
+    src: `
     JSON.stringify({f: function(){}});
     `,
-    expected: "{}" },
-
-  { name: 'JSON.stringify filter', src: `
+    expected: '{}'
+  },
+  {
+    name: 'JSON.stringify filter',
+    src: `
     JSON.stringify({
         string: 'foo', number: 42, true: true, false: false, null: null,
         object: { obj: {}, arr: [] }, array: [{}, []] },
         ['string', 'number']);
     `,
-    expected: '{"string":"foo","number":42}' },
-
-  { name: 'JSON.stringify pretty number', src: `
+    expected: '{"string":"foo","number":42}'
+  },
+  {
+    name: 'JSON.stringify pretty number',
+    src: `
     JSON.stringify({
         string: 'foo', number: 42, true: true, false: false, null: null,
         object: { obj: {}, arr: [] }, array: [{}, []] },
         ['string', 'number'], 2);
     `,
-    expected: '{\n  "string": "foo",\n  "number": 42\n}' },
-
-  { name: 'JSON.stringify pretty string', src: `
+    expected: '{\n  "string": "foo",\n  "number": 42\n}'
+  },
+  {
+    name: 'JSON.stringify pretty string',
+    src: `
     JSON.stringify({
         string: 'foo', number: 42, true: true, false: false, null: null,
         object: { obj: {}, arr: [] }, array: [{}, []] },
         ['string', 'number'], '--');
     `,
-    expected: '{\n--"string": "foo",\n--"number": 42\n}' },
-
-  { name: 'JSON.stringify nonenumerable', src: `
+    expected: '{\n--"string": "foo",\n--"number": 42\n}'
+  },
+  {
+    name: 'JSON.stringify nonenumerable',
+    src: `
     var obj = {e: 'enumerable', ne: 'nonenumerable'};
     Object.defineProperty(obj, 'ne', {enumerable: false});
     JSON.stringify(obj);
     `,
-    expected: '{"e":"enumerable"}' },
-
-  { name: 'JSON.stringify inherited', src: `
+    expected: '{"e":"enumerable"}'
+  },
+  {
+    name: 'JSON.stringify inherited',
+    src: `
     JSON.stringify(Object.create({foo: 'bar'}));
     `,
-    expected: '{}' },
-
-  { name: 'JSON.stringify circular', src: `
+    expected: '{}'
+  },
+  {
+    name: 'JSON.stringify circular',
+    src: `
     var obj = {};
     obj.circular = obj;
     try {
@@ -2706,24 +3317,26 @@ module.exports = [
       e.name;
     }
     `,
-    expected: 'TypeError' },
-
+    expected: 'TypeError'
+  },
   /////////////////////////////////////////////////////////////////////////////
   // Other built-in functions
-
-  { name: 'decodeURI throws', src: `
+  {
+    name: 'decodeURI throws',
+    src: `
     try {
       decodeURI('%xy');
     } catch (e) {
       e.name;
     }
     `,
-    expected: 'URIError' },
-
+    expected: 'URIError'
+  },
   /////////////////////////////////////////////////////////////////////////////
   // WeakMap
-
-  { name: 'WeakMap', src: `
+  {
+    name: 'WeakMap',
+    src: `
     var w = new WeakMap;
     var p = {};
     var o = Object.create(p);
@@ -2738,9 +3351,11 @@ module.exports = [
     !w.has(o) || fails++;
     fails;
     `,
-    expected: 0 },
-
-  { name: 'WeakMap.prototype methods reject non-WeakMap this', src: `
+    expected: 0
+  },
+  {
+    name: 'WeakMap.prototype methods reject non-WeakMap this',
+    src: `
     var w = new WeakMap;
     var fails = 0;
     function expectError(method, thisVal, args) {
@@ -2764,9 +3379,11 @@ module.exports = [
     }
     fails;
     `,
-    expected: 0 },
-
-  { name: 'WeakMap', src: `
+    expected: 0
+  },
+  {
+    name: 'WeakMap',
+    src: `
     var w = new WeakMap;
     var p = {};
     var o = Object.create(p);
@@ -2781,37 +3398,44 @@ module.exports = [
     !w.has(o) || fails++;
     fails;
     `,
-    expected: 0 },
-
+    expected: 0
+  },
   /////////////////////////////////////////////////////////////////////////////
   // Thread and Thread.prototype:
-
   // TODO(cpallen): change .eval to .program when test harness no
   //     longer relies on eval.
-  { name: 'Thread.callers() ownership', src: `
+  {
+    name: 'Thread.callers() ownership',
+    src: `
     var owner = {};
     setPerms(owner);
     var callers = Thread.callers();
     Object.getOwnerOf(callers) === owner &&
         Object.getOwnerOf(callers[0]) === owner;
     `,
-    expected: true },
-
-  { name: 'Thread.callers()[0].eval',
+    expected: true
+  },
+  {
+    name: 'Thread.callers()[0].eval',
     src: 'Thread.callers()[0].eval',
-    expected: 'Thread.callers()[0].eval' },
-
-  { name: 'Thread.callers()[0].line & .col',
+    expected: 'Thread.callers()[0].eval'
+  },
+  {
+    name: 'Thread.callers()[0].line & .col',
     src: 'var frame = Thread.callers()[0]; frame.line + "," + frame.col;',
-    expected: '1,13' },
-
-  { name: 'Thread.callers()[/*last*/].program', src: `
+    expected: '1,13'
+  },
+  {
+    name: 'Thread.callers()[/*last*/].program',
+    src: `
     var callers = Thread.callers();
     Boolean(callers[callers.length - 1].program);
     `,
-    expected: true },
-
-  { name: 'Thread.callers()[0].callerPerms', src: `
+    expected: true
+  },
+  {
+    name: 'Thread.callers()[0].callerPerms',
+    src: `
     CC.root.name = 'root';
     var user = {name: 'user'};
     function f() {
@@ -2820,30 +3444,38 @@ module.exports = [
     setPerms(user);
     f();
     `,
-    expected: 'user' },
-
+    expected: 'user'
+  },
   // Time limit tests.  Actual enforcement is tested in
   // interpreter_tests.js; this is just checking behaviour of get/set
   // builtins.
-  { name: 'Thread.prototype.getTimeLimit() initially 0', src: `
+  {
+    name: 'Thread.prototype.getTimeLimit() initially 0',
+    src: `
     Thread.current().getTimeLimit();
     `,
-    expected: 0 },
-
-  { name: 'Thread.prototype.setTimeLimit()', src: `
+    expected: 0
+  },
+  {
+    name: 'Thread.prototype.setTimeLimit()',
+    src: `
     Thread.current().setTimeLimit(1000);
     Thread.current().getTimeLimit();
     `,
-    expected: 1000 },
-
-  { name: 'Thread.prototype.setTimeLimit(...)', src: `
+    expected: 1000
+  },
+  {
+    name: 'Thread.prototype.setTimeLimit(...)',
+    src: `
     Thread.current().setTimeLimit(1000);
     Thread.current().getTimeLimit();
     `,
-    expected: 1000 },
-
+    expected: 1000
+  },
   // Check invalid time limits are rejected.
-  { name: 'Thread.prototype.setTimeLimit(/* invalid value */) throws', src: `
+  {
+    name: 'Thread.prototype.setTimeLimit(/* invalid value */) throws',
+    src: `
     Thread.current().setTimeLimit(1000);
     var invalid = [0, 1001, NaN, 'foo', true, {}];
     var failures = [];
@@ -2856,18 +3488,20 @@ module.exports = [
     }
     (failures.length === 0) ? 'OK' : String(failures);
     `,
-    expected: 'OK' },
-
+    expected: 'OK'
+  },
   /////////////////////////////////////////////////////////////////////////////
   // Permissions system:
-
-  { name: 'perms returns root', src: `
+  {
+    name: 'perms returns root',
+    src: `
     perms() === CC.root;
     `,
     expected: true
   },
-
-  { name: 'setPerms', src: `
+  {
+    name: 'setPerms',
+    src: `
     CC.root.name = 'Root';
     var bob = {};
     bob.name = 'Bob';
@@ -2882,8 +3516,9 @@ module.exports = [
     r;`,
     expected: 'RootBobRoot'
   },
-
-  { name: 'getOwnerOf', src: `
+  {
+    name: 'getOwnerOf',
+    src: `
     var bob = {};
     var roots = {};
     setPerms(bob);
@@ -2893,25 +3528,27 @@ module.exports = [
     Object.getOwnerOf(bobs) === bob`,
     expected: true
   },
-
-  { name: 'setOwnerOf', src: `
+  {
+    name: 'setOwnerOf',
+    src: `
     var bob = {};
     var obj = {};
     Object.setOwnerOf(obj, bob) === obj && Object.getOwnerOf(obj) === bob;
     `,
     expected: true
   },
-
   /////////////////////////////////////////////////////////////////////////////
   // Other tests:
-
-  { name: 'new hack', src: `
+  {
+    name: 'new hack',
+    src: `
     (new 'Array.prototype.push') === Array.prototype.push
     `,
     expected: true
   },
-
-  { name: 'new hack with unkown builtin', src: `
+  {
+    name: 'new hack with unkown builtin',
+    src: `
     try {
       new 'nonexistent-builtin-name';
     } catch (e) {
@@ -2920,8 +3557,9 @@ module.exports = [
     `,
     expected: 'ReferenceError'
   },
-
-  { name: 'new hack with other than string literal', src: `
+  {
+    name: 'new hack with other than string literal',
+    src: `
     try {
       var builtin = 'Object.prototype';
       new builtin;
@@ -2931,19 +3569,17 @@ module.exports = [
     `,
     expected: 'TypeError'
   },
-
-  { name: 'ES6 causes syntax errors', src: `
+  {
+    name: 'ES6 causes syntax errors',
+    src: `
     var tests = [
       // Class statements & expressions
       'class Foo{};',
       'false && class Foo{};',
-
       // Arrow functions.
       'false && [].map((item) => String(item));',
-
       // For-of statement.
       'for (var x of [1, 2, 3]) {};',
-
       // Let & const.
       'let x;',
       'const x;',
@@ -2963,22 +3599,19 @@ module.exports = [
     `,
     expected: 'OK'
   },
-
-  { name: 'Strict mode syntax errors', src: `
+  {
+    name: 'Strict mode syntax errors',
+    src: `
     var tests = [
       // With statement.
       'var o = { foo: 42 }; var f = function() { with (o) { foo; }};',
-
       // Binding eval in global scope, or arguments in a function.
       'var eval = "rebinding eval?!?";',
       '(function() { arguments = undefined; });',
-
       // Duplicate argument names.
       '(function(a, a) {});',
-
       // Octal numeric literals.
       '0777;',
-
       // Delete of unqualified or undeclared identifier.
       'var foo; delete foo;',
       'delete foo;',
@@ -2998,8 +3631,9 @@ module.exports = [
     `,
     expected: 'OK'
   },
-
-  { name: 'Stack overflow errors', src: `
+  {
+    name: 'Stack overflow errors',
+    src: `
     try {
       (function f() {f();})();
     } catch (e) {
@@ -3009,8 +3643,9 @@ module.exports = [
     options: {stackLimit: 100},
     expected: 'RangeError'
   },
-
-  { name: 'Minimum stack depth limit', src: `
+  {
+    name: 'Minimum stack depth limit',
+    src: `
     function f() {
       try {
         return f() + 1;

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -122,7 +122,7 @@ module.exports = [
     expected: 8
   },
   {
-    src: `var v, f = function() { v = 49; }; f(); v;
+    src: `var v, f = function() {v = 49;}; f(); v;
     `,
     expected: 49
   },
@@ -147,22 +147,22 @@ module.exports = [
   },
   {
     name: 'funExpWithParameter',
-    src: `var v; var f = function(x) { v = x; }; f(50); v;`,
+    src: `var v; var f = function(x) {v = x;}; f(50); v;`,
     expected: 50
   },
   {
     name: 'funExpParameterNotShadowedByVar',
-    src: `var f = function(x) { var x; return x; }; f(50.1);`,
+    src: `var f = function(x) {var x; return x;}; f(50.1);`,
     expected: 50.1
   },
   {
     name: 'funExpParameterNotShadowedByVar',
-    src: `var f = function(x) { var x = 50.2; return x; }; f(50.2);`,
+    src: `var f = function(x) {var x = 50.2; return x;}; f(50.2);`,
     expected: 50.2
   },
   {
     name: 'functionWithReturn',
-    src: `(function(x) { return x; })(51);`,
+    src: `(function(x) {return x;})(51);`,
     expected: 51
   },
   {
@@ -398,7 +398,7 @@ module.exports = [
     name: 'forIn',
     src: `
     var x = 0, a = {a: 60, b:3, c:4};
-    for (var i in a) { x += a[i]; }
+    for (var i in a) {x += a[i];}
     x;
     `,
     expected: 67
@@ -407,7 +407,7 @@ module.exports = [
     name: 'forInMemberExp',
     src: `
     var x = 1, o = {foo: 'bar'}, a = {a:2, b:2, c:17};
-    for (o.foo in a) { x *= a[o.foo]; }
+    for (o.foo in a) {x *= a[o.foo];}
     x;
     `,
     expected: 68
@@ -416,9 +416,9 @@ module.exports = [
     name: 'forInMembFunc',
     src: `
     var x = 0, o = {};
-    var f = function() { x += 20; return o; };
+    var f = function() {x += 20; return o;};
     var a = {a:2, b:3, c:4};
-    for (f().foo in a) { x += a[o.foo]; }
+    for (f().foo in a) {x += a[o.foo];}
     x;
     `,
     expected: 69
@@ -427,9 +427,9 @@ module.exports = [
     name: 'forInNullUndefined',
     src: `
     var x = 0, o = {};
-    var f = function() { x++; return o; };
-    for (f().foo in null) { x++; }
-    for (f().foo in undefined) { x++; }
+    var f = function() {x++; return o;};
+    for (f().foo in null) {x++;}
+    for (f().foo in undefined) {x++;}
     x;
     `,
     expected: 0
@@ -474,7 +474,7 @@ module.exports = [
     name: 'thisInMethod',
     src: `
     var o = {
-      f: function() { return this.foo; },
+      f: function() {return this.foo;},
       foo: 70
     };
     o.f();
@@ -484,7 +484,7 @@ module.exports = [
   {
     name: 'thisInFormerMethod',
     src: `
-    var o = { f: function() { return this; }};
+    var o = {f: function() {return this;}};
     var g = o.f;
     g();
     `,
@@ -917,7 +917,7 @@ module.exports = [
     name: 'closureIndependence',
     src: `
     function makeAdder(x) {
-      return function(y) { return x + y; };
+      return function(y) {return x + y;};
     }
     var plus3 = makeAdder(3);
     var plus4 = makeAdder(4);
@@ -1024,8 +1024,8 @@ module.exports = [
   {
     name: 'newExpression',
     src: `
-    function T(x, y) { this.sum += x + y; };
-    T.prototype = { sum: 70 }
+    function T(x, y) {this.sum += x + y;};
+    T.prototype = {sum: 70}
     var t = new T(7, 0.7);
     t.sum;
     `,
@@ -1034,8 +1034,8 @@ module.exports = [
   {
     name: 'newExpressionReturnObj',
     src: `
-    function T() { return {}; };
-    T.prototype = { p: 'the prototype' };
+    function T() {return {};};
+    T.prototype = {p: 'the prototype'};
     (new T).p;
     `,
     expected: undefined
@@ -1043,8 +1043,8 @@ module.exports = [
   {
     name: 'newExpressionReturnPrimitive',
     src: `
-    function T() { return 0; };
-    T.prototype = { p: 'the prototype' };
+    function T() {return 0;};
+    T.prototype = {p: 'the prototype'};
     (new T).p;
     `,
     expected: 'the prototype'
@@ -1078,7 +1078,7 @@ module.exports = [
     (function() {
       var n = 77.77;
       try {
-        (function() { return eval; })()('n');
+        (function() {return eval;})()('n');
       } catch (e) {
         return e.name;
       }
@@ -1127,7 +1127,7 @@ module.exports = [
     src: `
     try {
       var invalid = undefined;
-      function t() { throw {name: 'args'}; };
+      function t() {throw {name: 'args'};};
       invalid(t());
     } catch(e) {
       e.name;
@@ -1201,7 +1201,7 @@ module.exports = [
   {
     name: 'Object.defineProperty',
     src: `
-    var o = { foo: 50 }, r = 0;
+    var o = {foo: 50}, r = 0;
     Object.defineProperty(o, 'bar', {
       writable: true,
       enumerable: true,
@@ -1378,7 +1378,7 @@ module.exports = [
     name: 'Object.getOwnPropertyDescriptor',
     src: `
     var o = {}, r = 0;
-    Object.defineProperty(o, 'foo', { value: 'bar' });
+    Object.defineProperty(o, 'foo', {value: 'bar'});
     var desc = Object.getOwnPropertyDescriptor(o, 'foo');
     desc.value === o.foo &&
         !desc.writable && !desc.enumerable && !desc.configurable;
@@ -1445,7 +1445,7 @@ module.exports = [
     src: `
     var o = Object.create({baz: 999});
     o.foo = 42;
-    Object.defineProperty(o, 'bar', { value: 38 });
+    Object.defineProperty(o, 'bar', {value: 38});
     var keys = Object.getOwnPropertyNames(o);
     var r = 0;
     for (var i = 0; i < keys.length; i++) {
@@ -1493,7 +1493,7 @@ module.exports = [
     src: `
     var o = {};
     try {
-      Object.defineProperties(o, { foo: 'not an object' });
+      Object.defineProperties(o, {foo: 'not an object'});
     } catch (e) {
       e.name;
     }
@@ -1503,14 +1503,14 @@ module.exports = [
   {
     name: 'Object.defineProperties',
     src: `
-    var o = { foo: 70 }, r = 0;
+    var o = {foo: 70}, r = 0;
     Object.defineProperties(o, {
         bar: {
             writable: true,
             enumerable: true,
             configurable: true,
             value: 8 },
-        baz: { value: 999 }});
+        baz: {value: 999}});
     for (var k in o) {
       r += o[k];
     }
@@ -1521,13 +1521,13 @@ module.exports = [
   {
     name: 'Object.create(..., properties)',
     src: `
-    var o = Object.create({ foo: 70 }, {
+    var o = Object.create({foo: 70}, {
         bar: {
             writable: true,
             enumerable: true,
             configurable: true,
             value: 10 },
-        baz: { value: 999 }});
+        baz: {value: 999}});
     var r = 0;
     for (var k in o) {
       r += o[k];
@@ -1729,7 +1729,7 @@ module.exports = [
     name: 'Function.prototype.apply this',
     src: `
     var o = {};
-    function f() { return this; }
+    function f() {return this;}
     f.apply(o, []) === o;
     `,
     expected: true
@@ -1738,7 +1738,7 @@ module.exports = [
     name: 'Function.prototype.apply(..., undefined) or null',
     src: `
     var n = 0;
-    function f() { n += arguments.length; }
+    function f() {n += arguments.length;}
     f.apply(undefined, undefined);
     f.apply(undefined, null);
     n;
@@ -1803,7 +1803,7 @@ module.exports = [
     name: 'Function.prototype.call this',
     src: `
     var o = {};
-    function f() { return this; }
+    function f() {return this;}
     f.call(o) === o;
     `,
     expected: true
@@ -1842,14 +1842,14 @@ module.exports = [
     name: 'Function.prototype.bind this',
     src: `
     var o = {};
-    function f() { return this; }
+    function f() {return this;}
     f.bind(o)() === o;
     `,
     expected: true
   },
   {
     name: 'Function.prototype.bind no args',
-    src: `(function() { return arguments.length; }).bind()();`,
+    src: `(function() {return arguments.length;}).bind()();`,
     expected: 0
   },
   {
@@ -2903,7 +2903,7 @@ module.exports = [
     src: `
     JSON.stringify({
         string: 'foo', number: 42, true: true, false: false, null: null,
-        object: { obj: {}, arr: [] }, array: [{}, []] });
+        object: {obj: {}, arr: []}, array: [{}, []] });
     `,
     expected: '{"string":"foo","number":42,"true":true,"false":false,' +
         '"null":null,"object":{"obj":{},"arr":[]},"array":[{},[]]}'
@@ -2925,7 +2925,7 @@ module.exports = [
     src: `
     JSON.stringify({
         string: 'foo', number: 42, true: true, false: false, null: null,
-        object: { obj: {}, arr: [] }, array: [{}, []] },
+        object: {obj: {}, arr: []}, array: [{}, []] },
         ['string', 'number']);
     `,
     expected: '{"string":"foo","number":42}'
@@ -2935,7 +2935,7 @@ module.exports = [
     src: `
     JSON.stringify({
         string: 'foo', number: 42, true: true, false: false, null: null,
-        object: { obj: {}, arr: [] }, array: [{}, []] },
+        object: {obj: {}, arr: []}, array: [{}, []] },
         ['string', 'number'], 2);
     `,
     expected: '{\n  "string": "foo",\n  "number": 42\n}'
@@ -2945,7 +2945,7 @@ module.exports = [
     src: `
     JSON.stringify({
         string: 'foo', number: 42, true: true, false: false, null: null,
-        object: { obj: {}, arr: [] }, array: [{}, []] },
+        object: {obj: {}, arr: []}, array: [{}, []] },
         ['string', 'number'], '--');
     `,
     expected: '{\n--"string": "foo",\n--"number": 42\n}'
@@ -3256,10 +3256,10 @@ module.exports = [
     src: `
     var tests = [
       // With statement.
-      'var o = { foo: 42 }; var f = function() { with (o) { foo; }};',
+      'var o = {foo: 42}; var f = function() {with (o) {foo;}};',
       // Binding eval in global scope, or arguments in a function.
       'var eval = "rebinding eval?!?";',
-      '(function() { arguments = undefined; });',
+      '(function() {arguments = undefined;});',
       // Duplicate argument names.
       '(function(a, a) {});',
       // Octal numeric literals.

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -92,9 +92,9 @@ module.exports = [
     expected: 8,
   },
   {
-    src: `var v, f = function() {v = 49;}; f(); v;
-    `,
-    expected: 49
+    name: 'FunctionExpression',
+    src: `var v, f = function() {v = 49;}; f(); v;`,
+    expected: 49,
   },
   {
     name: 'assignmentSetsAnonFuncName',
@@ -195,12 +195,12 @@ module.exports = [
   {
     src: `try {throw new Error('not caught');} finally {}`,
     options: {noLog: ['unhandled']},
-    expected: undefined
+    expected: undefined,
   },
   {
     src: `try {throw 'not caught';} finally {}`,
     options: {noLog: ['unhandled']},
-    expected: undefined
+    expected: undefined,
   },
   {src: `51, 52, 53;`, expected: 53},
   {
@@ -259,7 +259,7 @@ module.exports = [
   },
   {
     src: `foo: break foo;`,
-    expected: undefined /* (but legal!) */
+    expected: undefined,  // (but legal!)
   },
   {
     name: 'try ... break ... finally',
@@ -1072,6 +1072,7 @@ module.exports = [
     `,
     expected: 'pass',
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // Object and Object.prototype
   {
@@ -1556,6 +1557,7 @@ module.exports = [
     `,
     expected: true,
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // Function and Function.prototype
   {
@@ -1811,6 +1813,7 @@ module.exports = [
     src: `String(new (WeakMap.bind()));`,
     expected: '[object WeakMap]',
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // Array and Array.prototype
   {
@@ -2355,6 +2358,7 @@ module.exports = [
     // SKIP until more efficient unshift implementation available.
     /* expected: true */
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // Boolean and Boolean.prototype
   {src: `Boolean(undefined);`, expected: false},
@@ -2398,6 +2402,7 @@ module.exports = [
     `,
     expected: 'TypeError',
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // Number and Number.prototype
   {src: `Number();`, expected: 0},
@@ -2448,6 +2453,7 @@ module.exports = [
     `,
     expected: 'TypeError',
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // String and String.prototype
   {src: `String();`, expected: ''},
@@ -2610,6 +2616,7 @@ module.exports = [
     `,
     expected: 'TypeError',
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // RegExp
   {
@@ -2623,6 +2630,7 @@ module.exports = [
     `,
     expected: 'TypeError',
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // Error and Error.prototype (and all the other native error types too)
   {
@@ -2691,6 +2699,7 @@ module.exports = [
     `,
     expected: 'at foo 2:16',
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // JSON
   {
@@ -2763,6 +2772,7 @@ module.exports = [
     `,
     expected: 'TypeError',
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // Other built-in functions
   {
@@ -2776,6 +2786,7 @@ module.exports = [
     `,
     expected: 'URIError',
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // WeakMap
   {
@@ -2845,6 +2856,7 @@ module.exports = [
     `,
     expected: 0,
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // Thread and Thread.prototype:
   // TODO(cpallen): change .eval to .program when test harness no
@@ -2858,16 +2870,16 @@ module.exports = [
       Object.getOwnerOf(callers) === owner &&
           Object.getOwnerOf(callers[0]) === owner;
     `,
-    expected: true
+    expected: true,
   },
   {
     name: 'Thread.callers()[0].eval',
-    src: 'Thread.callers()[0].eval',
-    expected: 'Thread.callers()[0].eval'
+    src: `Thread.callers()[0].eval`,
+    expected: 'Thread.callers()[0].eval',
   },
   {
     name: 'Thread.callers()[0].line & .col',
-    src: 'var frame = Thread.callers()[0]; frame.line + "," + frame.col;',
+    src: `var frame = Thread.callers()[0]; frame.line + "," + frame.col;`,
     expected: '1,13',
   },
   {
@@ -2933,6 +2945,7 @@ module.exports = [
     `,
     expected: 'OK',
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // Permissions system:
   {
@@ -2980,6 +2993,7 @@ module.exports = [
     `,
     expected: true,
   },
+
   /////////////////////////////////////////////////////////////////////////////
   // Other tests:
   {

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -21,8 +21,8 @@
  */
 'use strict';
 
+// Testcases for testSimple in interpreter_test.js.
 module.exports = [
-  // Testcases for TestInterpreterSimple (have expected value):
   {
     src: `1 + 1;`,
     expected: 2
@@ -1784,8 +1784,8 @@ module.exports = [
       return a + b + c;
     }).apply(undefined, {0: 1, 1: 2, 2: 4});
     `,
-    expected: NaN
-  },  // Because undefined + undefined === NaN.
+    expected: NaN  // Because undefined + undefined === NaN.
+  },
   {
     name: 'Function.prototype.call non-function throws',
     src: `
@@ -1898,7 +1898,7 @@ module.exports = [
     `,
     expected: 'TypeError'
   },
-  // N.B.: tests of class constructor semantics unavoidably ES6.
+  // N.B.: tests of semantics of class constructors are unavoidably ES6.
   {
     name: 'Function.prototype.bind class constructor w/o new',
     src: `
@@ -1911,7 +1911,7 @@ module.exports = [
     `,
     expected: 'TypeError'
   },
-  // N.B.: tests of class constructor semantics unavoidably ES6.
+  // N.B.: tests of semantics of class constructors are unavoidably ES6.
   {
     name: 'Function.prototype.bind class constructor',
     src: `String(new (WeakMap.bind()));`,
@@ -3030,10 +3030,11 @@ module.exports = [
       var method = methods[i];
       for (var j = 0; j < values.length; j++) {
         var value = values[j];
-        expectError(method, value, [{}]);
-        expectError(method, w, [value]);
+        expectError(method, value, [{}]);  // Can't call method on non-WeakMap.
+        expectError(method, w, [value]);  // Can't store non-object in WeakMap.
       }
-      expectError(method, WeakMap.prototpye, [{}]);  // Ordinary object.
+      // WeakMap.prototype is an ordinary object, not a WeakMap.
+      expectError(method, WeakMap.prototpye, [{}]);
     }
     fails;
     `,

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -593,29 +593,15 @@ module.exports = [
   {src: `-73;`, expected: -73},
   {src: `~0xffffffb5;`, expected: 74},
   {src: `!false && (!true === false);`, expected: true},
-  {
-    name: 'unaryTypeof',
-    src: `
-      var tests = [
-        [undefined, 'undefined'],
-        [null, 'object'],
-        [false, 'boolean'],
-        [0, 'number'],
-        ['', 'string'],
-        [{}, 'object'],
-        [[], 'object'],
-        [function() {}, 'function'],
-      ];
-      var ok = 0;
-      for (var i = 0; i < tests.length; i++) {
-        if (typeof tests[i][0] === tests[i][1]) {
-          ok++;
-        }
-      }
-      (ok === tests.length) ? 'pass' : 'fail';
-    `,
-    expected: 'pass',
-  },
+
+  {src: `typeof undefined;`, expected: 'undefined'},
+  {src: `typeof null;`, expected: 'object'},
+  {src: `typeof false;`, expected: 'boolean'},
+  {src: `typeof 0;`, expected: 'number'},
+  {src: `typeof '';`, expected: 'string'},
+  {src: `typeof {};`, expected: 'object'},
+  {src: `typeof [];`, expected: 'object'},
+  {src: `typeof function() {};`, expected: 'function'},
   {
     name: 'unaryTypeofUndeclared',
     src: `
@@ -2371,33 +2357,19 @@ module.exports = [
   },
   /////////////////////////////////////////////////////////////////////////////
   // Boolean and Boolean.prototype
-  {
-    name: 'Boolean',
-    src: `
-      var tests = [
-        [undefined, false],
-        [null, false],
-        [false, false],
-        [true, true],
-        [NaN, false],
-        [0, false],
-        [1, true],
-        ['', false],
-        ['foo', true],
-        [{}, true],
-        [[], true],
-        [function() {}, true],
-      ];
-      var ok = 0;
-      for (var i = 0; i < tests.length; i++) {
-        if (Boolean(tests[i][0]) === tests[i][1]) {
-          ok++;
-        }
-      }
-      (ok === tests.length) ? 'pass' : 'fail';
-    `,
-    expected: 'pass',
-  },
+  {src: `Boolean(undefined);`, expected: false},
+  {src: `Boolean(null);`, expected: false},
+  {src: `Boolean(false);`, expected: false},
+  {src: `Boolean(true);`, expected: true},
+  {src: `Boolean(NaN);`, expected: false},
+  {src: `Boolean(0);`, expected: false},
+  {src: `Boolean(1);`, expected: true},
+  {src: `Boolean('');`, expected: false},
+  {src: `Boolean('foo');`, expected: true},
+  {src: `Boolean({});`, expected: true},
+  {src: `Boolean([]);`, expected: true},
+  {src: `Boolean(function() {});`, expected: true},
+
   {src: `Boolean.prototype.toString();`, expected: 'false'},
   {src: `Boolean.prototype.toString.call(true);`, expected: 'true'},
   {src: `Boolean.prototype.toString.call(false);`, expected: 'false'},
@@ -2428,33 +2400,19 @@ module.exports = [
   },
   /////////////////////////////////////////////////////////////////////////////
   // Number and Number.prototype
-  {name: 'Number()', src: 'Number();', expected: 0},
-  {
-    name: 'Number',
-    src: `
-      var tests = [
-        [undefined, NaN],
-        [null, 0],
-        [true, 1],
-        [false, 0],
-        ['42', 42],
-        ['', 0],
-        [{}, NaN],
-        [[], 0],
-        [[42], 42],
-        [[1,2,3], NaN],
-        [function() {}, NaN],
-      ];
-      var ok = 0;
-      for (var i = 0; i < tests.length; i++) {
-        if (Object.is(Number(tests[i][0]), tests[i][1])) {
-          ok++;
-        }
-      }
-      (ok === tests.length) ? 'pass' : 'fail';
-    `,
-    expected: 'pass',
-  },
+  {src: `Number();`, expected: 0},
+  {src: `Number(undefined);`, expected: NaN},
+  {src: `Number(null);`, expected: 0},
+  {src: `Number(true);`, expected: 1},
+  {src: `Number(false);`, expected: 0},
+  {src: `Number('42');`, expected: 42},
+  {src: `Number('');`, expected: 0},
+  {src: `Number({});`, expected: NaN},
+  {src: `Number([]);`, expected: 0},
+  {src: `Number([42]);`, expected: 42},
+  {src: `Number([1,2,3]);`, expected: NaN},
+  {src: `Number(function() {});`, expected: NaN},
+
   {
     name: 'Number.MAX_SAFE_INTEGER',
     src: `
@@ -2492,33 +2450,19 @@ module.exports = [
   },
   /////////////////////////////////////////////////////////////////////////////
   // String and String.prototype
-  {name: 'String()', src: 'String();', expected: ''},
-  {
-    name: 'String',
-    src: `
-      var tests = [
-        [undefined, 'undefined'],
-        [null, 'null'],
-        [true, 'true'],
-        [false, 'false'],
-        [0, '0'],
-        [-0, '0'],
-        [Infinity, 'Infinity'],
-        [-Infinity, '-Infinity'],
-        [NaN, 'NaN'],
-        [{}, '[object Object]'],
-        [[1, 2, 3,,5], '1,2,3,,5'],
-      ];
-      var ok = 0;
-      for (var i = 0; i < tests.length; i++) {
-        if (String(tests[i][0]) === tests[i][1]) {
-          ok++;
-        }
-      }
-      (ok === tests.length) ? 'pass' : 'fail';
-    `,
-    expected: 'pass',
-  },
+  {src: `String();`, expected: ''},
+  {src: `String(undefined);`, expected: 'undefined'},
+  {src: `String(null);`, expected: 'null'},
+  {src: `String(true);`, expected: 'true'},
+  {src: `String(false);`, expected: 'false'},
+  {src: `String(0);`, expected: '0'},
+  {src: `String(-0);`, expected: '0'},
+  {src: `String(Infinity);`, expected: 'Infinity'},
+  {src: `String(-Infinity);`, expected: '-Infinity'},
+  {src: `String(NaN);`, expected: 'NaN'},
+  {src: `String({});`, expected: '[object Object]'},
+  {src: `String([1, 2, 3,,5]);`, expected: '1,2,3,,5'},
+
   {
     name: 'String calls valueOf',
     src: `


### PR DESCRIPTION
Numerous mostly-reformatting changes to `server/tests/testcases.js`:

* Run `clang-format` on the file to fix various formatting sins.
* Remove extraneous blank lines between testcases.
* Reduce simple testcases to a single line (and put source on the same line as the `src:` tag).
* Remove `name`s from testcases where it is the same as `src` or where it does not contribute any useful information about the purpose of the test.
* Fix formatting of the testcase source code itself:
  * Consistently indent source code by +2 spaces compared to surrounding testcase.
  * Apply certain [styleguide](https://google.github.io/styleguide/jsguide.html) rules regarding whitespace, line breaks, etc.
* Make selective improvements to testcase naming and comments.
* Don't use table-driven tests (within a single testcase) unnecessarily.
  * There are still some cases of table-driven tests where we are checking for certain errors being thrown, which is harder to to concisely as a top-level testcase.

Also:

* Backport a doc fix for `regexps.identifier` in `server/code.js` from the core.
* Add two tests concerning setting anonymous FunctionExpression `.name` properties by property assignment.