### PR TITLE
Fix crashes caused by calling .toString() method on non-Interpreter.prototype.Objects

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2094,7 +2094,7 @@ Interpreter.prototype.initJSON_ = function() {
   var wrapper;
   wrapper = function(text) {
     try {
-      var nativeObj = JSON.parse(text.toString());
+      var nativeObj = JSON.parse(String(text));
     } catch (e) {
       throw intrp.errorNativeToPseudo(e, intrp.thread_.perms());
     }

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -2639,11 +2639,132 @@ module.exports = [
 
   /////////////////////////////////////////////////////////////////////////////
   // RegExp
+  {src: `new RegExp(undefined).source`, expected: '(?:)'},
+  {src: `new RegExp(null).source`, expected: 'null'},
+  {src: `new RegExp(true).source`, expected: 'true'},
+  {src: `new RegExp(false).source`, expected: 'false'},
+  {src: `new RegExp('').source`, expected: '(?:)'},
+  {src: `new RegExp('foo').source`, expected: 'foo'},
+  {src: `new RegExp('0').source`, expected: '0'},
+  {src: `new RegExp({}).source`, expected: '[object Object]'},
+  {src: `new RegExp([]).source`, expected: '(?:)'},
+
+  {src: `RegExp(undefined).source`, expected: '(?:)'},
+  {src: `RegExp(null).source`, expected: 'null'},
+  {src: `RegExp(true).source`, expected: 'true'},
+  {src: `RegExp(false).source`, expected: 'false'},
+  {src: `RegExp('').source`, expected: '(?:)'},
+  {src: `RegExp('foo').source`, expected: 'foo'},
+  {src: `RegExp('0').source`, expected: '0'},
+  {src: `RegExp({}).source`, expected: '[object Object]'},
+  {src: `RegExp([]).source`, expected: '(?:)'},
+
+  // TODO(ES6):
+  // {src: `new RegExp('foo', '').flags`, expected: ''},
+  // {src: `new RegExp('foo', 'g').flags`, expected: 'g'},
+  // {src: `new RegExp('foo', 'i').flags`, expected: 'i'},
+  // {src: `new RegExp('foo', 'gi').flags`, expected: 'gi'},
+  // {src: `new RegExp('foo', 'm').flags`, expected: 'm'},
+  // {src: `new RegExp('foo', 'gm').flags`, expected: 'gm'},
+  // {src: `new RegExp('foo', 'im').flags`, expected: 'im'},
+  // {src: `new RegExp('foo', 'gim').flags`, expected: 'gim'},
+
+  {src: `new RegExp('foo', '').global`, expected: false},
+  {src: `new RegExp('foo', 'g').global`, expected: true},
+  {src: `new RegExp('foo', '').ignoreCase`, expected: false},
+  {src: `new RegExp('foo', 'i').ignoreCase`, expected: true},
+  {src: `new RegExp('foo', '').multiline`, expected: false},
+  {src: `new RegExp('foo', 'm').multiline`, expected: true},
+
   {
-    name: 'RegExp.prototype.test.apply(non-regexp) throws',
+    name: "new RegExp('', 'x') throws",
     src: `
       try {
-        /foo/.test.apply({}, ['foo']);
+        new RegExp('', 'x');
+      } catch (e) {
+        e.name;
+      }
+    `,
+    expected: 'SyntaxError',
+  },
+  {
+    name: "new RegExp('', 'gg') throws",
+    src: `
+      try {
+        new RegExp('', 'gg');
+      } catch (e) {
+        e.name;
+      }
+    `,
+    expected: 'SyntaxError',
+  },
+
+  // Check behaviour of RegExp when called with and without new, when
+  // pattern is itself a RegExp, and flags are or are not supplied.
+  {src: `var re = /foo/; new RegExp(re) === re;`, expected: false},
+  {src: `var re = /foo/; RegExp(re) === re;`, expected: true},
+  {src: `var re = /foo/; RegExp(re, 'm') === re;`, expected: false},
+  {src: `var re = /foo/m; RegExp(re, 'm') === re;`, expected: false},
+  {src: `var re = /foo/m; RegExp(re) === re;`, expected: true},
+  {
+    name: 'RegExp called as function checks .constructor',
+    src: `
+      function SubClass() {};
+      Object.setPrototypeOf(SubClass, RegExp);
+      Object.setPrototypeOf(SubClass.prototype, RegExp.prototype);
+      var re = /foo/;
+      re.constructor = SubClass;
+      RegExp(re) === re;
+    `,
+    expected: false,
+  },
+  // TODO(ES6):
+  // {src: `var re = /foo/m; RegExp(re, 'i').flags;`, expected: 'i'},
+  {src: `var re = /foo/m; RegExp(re, 'i').multiline;`, expected: false},
+  {src: `var re = /foo/m; RegExp(re, 'i').ignoreCase;`, expected: true},
+
+
+  // Check behaviour of RegExp.prototype methods.
+  {
+    name: 'RegExp.prototype.exec.call(undefined) throws',
+    src: `
+      try {
+        RegExp.prototype.exec.call(undefined, 'foo');
+      } catch (e) {
+        e.name;
+      }
+    `,
+    expected: 'TypeError',
+  },
+  {
+    name: 'RegExp.prototype.exec.call(non-regexp) throws',
+    src: `
+      try {
+        RegExp.prototype.exec.call({}, 'foo');
+      } catch (e) {
+        e.name;
+      }
+    `,
+    expected: 'TypeError',
+  },
+  {src: `/undefined/.exec(undefined).length;`, expected: 1},
+  {src: `/null/.exec(null).length;`, expected: 1},
+  {
+    name: 'RegExp.prototype.test.call(undefined) throws',
+    src: `
+      try {
+        RegExp.prototype.test.call(undefined);
+      } catch (e) {
+        e.name;
+      }
+    `,
+    expected: 'TypeError'
+  },
+  {
+    name: 'RegExp.prototype.test.call(/* non-regexp */) throws',
+    src: `
+      try {
+        RegExp.Prototype.test.call({}, 'foo');
       } catch (e) {
         e.name;
       }

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -2723,7 +2723,63 @@ module.exports = [
   /////////////////////////////////////////////////////////////////////////////
   // JSON
   {
-    name: 'JSON.stringify basic',
+    name: 'JSON.parse(undefined) throws',
+    src: `
+      try {
+        JSON.parse(undefined);
+      } catch (e) {
+        e.name;
+      }
+    `,
+    expected: 'SyntaxError',
+  },
+  {src: `JSON.parse(null);`, expected: null},
+  {src: `JSON.parse(true);`, expected: true},
+  {src: `JSON.parse(false);`, expected: false},
+  {src: `JSON.parse(42);`, expected: 42},
+  {
+    name: "JSON.parse('') throws",
+    src: `
+      try {
+        JSON.parse('');
+      } catch (e) {
+        e.name;
+      }
+    `,
+    expected: 'SyntaxError',
+  },
+  {
+    name: 'JSON.parse([]) throws',
+    src: `
+      try {
+        JSON.parse([]);  // Equivalent to JSON.parse('');
+      } catch (e) {
+        e.name;
+      }
+    `,
+    expected: 'SyntaxError',
+  },
+  {
+    name: 'JSON.parse({}) throws',
+    src: `
+      try {
+        JSON.parse({});  // Equivalent to JSON.parse('[object Object]');
+      } catch (e) {
+        e.name;
+      }
+    `,
+    expected: 'SyntaxError',
+  },
+
+  {src: `JSON.stringify(undefined);`, expected: undefined},
+  {src: `JSON.stringify(null);`, expected: 'null'},
+  {src: `JSON.stringify(true);`, expected: 'true'},
+  {src: `JSON.stringify(false);`, expected: 'false'},
+  {src: `JSON.stringify(42);`, expected: '42'},
+  {src: `JSON.stringify('string');`, expected: '"string"'},
+  {src: `JSON.stringify([1,2,,4]);`, expected: '[1,2,null,4]'},
+  {
+    name: 'JSON.stringify({...})',
     src: `
       JSON.stringify({
           string: 'foo', number: 42, true: true, false: false, null: null,
@@ -2736,7 +2792,7 @@ module.exports = [
   {src: `JSON.stringify([function(){}]);`, expected: '[null]'},
   {src: `JSON.stringify({f: function(){}});`, expected: '{}'},
   {
-    name: 'JSON.stringify filter',
+    name: 'JSON.stringify({...}, [/* filter array */])',
     src: `
       JSON.stringify({
           string: 'foo', number: 42, true: true, false: false, null: null,
@@ -2746,7 +2802,7 @@ module.exports = [
     expected: '{"string":"foo","number":42}',
   },
   {
-    name: 'JSON.stringify pretty number',
+    name: 'JSON.stringify({...}, [...], /* space number */)',
     src: `
       JSON.stringify({
           string: 'foo', number: 42, true: true, false: false, null: null,
@@ -2756,7 +2812,7 @@ module.exports = [
     expected: '{\n  "string": "foo",\n  "number": 42\n}',
   },
   {
-    name: 'JSON.stringify pretty string',
+    name: 'JSON.stringify({...}, [...], /* space  string */)',
     src: `
       JSON.stringify({
           string: 'foo', number: 42, true: true, false: false, null: null,
@@ -2766,7 +2822,7 @@ module.exports = [
     expected: '{\n--"string": "foo",\n--"number": 42\n}',
   },
   {
-    name: 'JSON.stringify nonenumerable',
+    name: 'JSON.stringify ignores nonenumerable properties',
     src: `
       var obj = {e: 'enumerable', ne: 'nonenumerable'};
       Object.defineProperty(obj, 'ne', {enumerable: false});
@@ -2775,12 +2831,12 @@ module.exports = [
     expected: '{"e":"enumerable"}',
   },
   {
-    name: 'JSON.stringify inherited',
+    name: 'JSON.stringify ignores inherited properties',
     src: `JSON.stringify(Object.create({foo: 'bar'}));`,
     expected: '{}',
   },
   {
-    name: 'JSON.stringify circular',
+    name: 'JSON.stringify throws when value is cyclic',
     src: `
       var obj = {};
       obj.circular = obj;


### PR DESCRIPTION
Fixes #474 by removing calls to `.toString()` where we are not 100% certain that the value it is being called on is an `Interpreter.prototype.Object`.

Along the way, add a lot of tests for `JSON.parse`, `JSON.stringify` and the `RegExp` constructor, and rewrite the latter as a (new-style) `NativeFunction`.