### PR TITLE
More tests tidying

### DIFF
--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -319,27 +319,27 @@ exports.testStrictBoxedThis = function(t) {
  */
 exports.testSwitchStatementFallthrough = function(t) {
   const code = `
-      var x = 0;
+      var x = '';
       switch (i) {
         case 1:
-          x += 1;
+          x += '1';
           // fall through
         case 2:
-          x += 2;
+          x += '2';
           // fall through
         default:
-          x += 16;
+          x += 'D';
           // fall through
         case 3:
-          x += 4;
+          x += '3';
           // fall through
         case 4:
-          x += 8;
+          x += '4';
           // fall through
       }
       x;`;
-  const expected = [28, 31, 30, 12, 8];
- for (let i = 0; i < expected.length; i++) {
+  const expected = ['D34', '12D34', '2D34', '34', '4'];
+  for (let i = 0; i < expected.length; i++) {
     const src = 'var i = ' + i + ';\n' + code;
     runSimpleTest(t, 'switch fallthrough ' + i, src, expected[i]);
   }

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -275,22 +275,27 @@ exports.testHasArgumentsOrEval = function(t) {
 };
 
 ///////////////////////////////////////////////////////////////////////////////
-// Tests: external simple testcases
+// Tests: run tests from testcases.js.
 ///////////////////////////////////////////////////////////////////////////////
 
 /**
  * Run the simple tests in testcases.js
  * @param {!T} t The test runner object.
  */
-exports.testSimple = function(t) {
+exports.testTestcases = function(t) {
   for (const tc of testcases) {
-    if ('expected' in tc) {
+    if (!('expected' in tc)) {
+      t.skip(tc.name);
+      continue;
+    }
+    if (tc.destructive) {
+      const testOptions = tc.options ? {options: tc.options} : {};
+      runTest(t, tc.name || tc.src, tc.src, tc.expected, testOptions);
+    } else {
       const oldOptions = interpreter.options;
       if (tc.options) interpreter.options = tc.options;
       runSimpleTest(t, tc.name || tc.src, tc.src, tc.expected);
       if (tc.options) interpreter.options = oldOptions;
-    } else {
-      t.skip(tc.name);
     }
   }
 };
@@ -298,20 +303,6 @@ exports.testSimple = function(t) {
 ///////////////////////////////////////////////////////////////////////////////
 // Tests: interpreter internals
 ///////////////////////////////////////////////////////////////////////////////
-
-/**
- * Run a (destructive) test to ensure that 'this' is a primitive in
- * methods invoked on primitives.  (This also tests that interpreter
- * is running in strict mode; in sloppy mode this will be boxed.)
- */
-exports.testStrictBoxedThis = function(t) {
-  let name = 'strictBoxedThis';
-  let src = `
-      String.prototype.foo = function() {return typeof this;};
-      'a primitive string'.foo();
-  `;
-  runTest(t, name, src, 'string');  // Not simple: modifies String.prototype
-};
 
 /**
  * Run some tests of switch statement with fallthrough.

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -1253,21 +1253,6 @@ exports.testClasses = function(t) {
 };
 
 /**
- * Run a destructive test of Function.prototype.toString.
- * @param {!T} t The test runner object.
- */
-exports.testFunctionPrototypeToString = function(t) {
-  let name = 'Funciton.prototype.toString applied to anonymous NativeFunction';
-  let src = `
-      var parent = function parent() {};
-      delete escape.name;
-      Object.setPrototypeOf(escape, parent);
-      escape.toString().replace(/\\s*/g, '');  // Strip whitespace.
-  `;
-  runTest(t, name, src, 'function(){[nativecode]}');  // Modifies escape.
-};
-
-/**
  * Run a test of multiple simultaneous calls to Array.prototype.join.
  * @param {!T} t The test runner object.
  */

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -564,39 +564,6 @@ exports.testBinaryOp = function(t) {
 };
 
 /**
- * Run tests of setting the name of an anonymous function in an
- * assignment expression where the LHS is a member expression.  This
- * is CodeCity-specific behaviour controlled by a server flag.
- */
-exports.testFunctionNameSetting = function(t) {
-  // Tests of the methodNames option which causes the functions that
-  // result from evaluating anonymous function expressions to get a
-  // .name when assigned to a property.
-  let name = "Assignment to property doesn't set anonymous function name";
-  let src = `
-      var o = {};
-      o.myMethod = function() {};
-      var gOPD = new 'Object.getOwnPropertyDescriptor';
-      gOPD(o.myMethod, 'name');
-  `;
-  runTest(t, name, src, undefined, {
-    options: {methodNames: false},
-    standardInit: false,  // Save time.
-  });
-
-  name = 'Assignment to property sets anonymous function name';
-  src = `
-      var o = {};
-      o.myMethod = function() {};
-      o.myMethod.name;
-  `;
-  runTest(t, name, src, 'myMethod', {
-    options: {methodNames: true},
-    standardInit: false,  // Save time.
-  });
-};
-
-/**
  * Run some tests of the Abstract Relational Comparison Algorithm, as
  * defined in §11.8.5 of the ES5.1 spec and as embodied by the '<'
  * operator.

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1643,6 +1643,22 @@ module.exports = [
     expected: 'TypeError',
   },
   {
+    name: 'Function.prototype.toSting on NativeFunction',
+    src: `escape.toString();`,
+    expected: 'function escape() { [native code] }',
+  },
+  {
+    name: 'Function.prototype.toSting on modified NativeFunction',
+    destructive: true,  // Modifies escape.
+    src: `
+      // Delete escape's original .name make it inherit a new one.
+      delete escape.name;
+      Object.setPrototypeOf(escape, function parent() {});
+      escape.toString();
+    `,
+    expected: 'function () { [native code] }',
+  },
+  {
     name: 'Function.prototype.apply.call(/* non-function */) throws',
     src: `
       try {

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -446,29 +446,43 @@ module.exports = [
     expected: 'ok',
   },
   {
-    name: 'thisInMethod',
+    name: 'value of this in function call',
     src: `
-      var o = {
-        f: function() {return this.foo;},
-        foo: 70
-      };
-      o.f();
-    `,
-    expected: 70,
-  },
-  {
-    name: 'thisInFormerMethod',
-    src: `
-      var o = {f: function() {return this;}};
-      var g = o.f;
-      g();
+      var f = function() {return this;};
+      f();
     `,
     expected: undefined,
   },
   {
-    name: 'thisGlobal',
-    src: `this;`,
+    name: 'value of this in method call',
+    src: `
+      var obj = {method: function() {return this;}};
+      obj.method() === obj;
+    `,
+    expected: true,
+  },
+  {
+    name: 'value of this in method called as function',
+    src: `
+      var obj = {method: function() {return this;}};
+      var f = obj.method;
+      f();
+    `,
     expected: undefined,
+  },
+  {
+    name: 'value of this outside function body',
+    src: `this === undefined;`,
+    expected: true,
+  },
+  {
+    name: 'value of this not boxed (in strict mode)',
+    destructive: true,  // Modifies String.prototype!
+    src: `
+      String.prototype.method = function() {return typeof this;};
+      'a primitive string'.method();
+    `,
+    expected: 'string',  // Would be an [object String] in non-strict mode.
   },
   {src: `[].length;`, expected: 0},
   {src: `[1,,3,,].length;`, expected: 4},

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1596,34 +1596,34 @@ module.exports = [
   // Function and Function.prototype
   {
     name: 'new Function() returns callable',
-    src: `(new Function)();`,
+    src: `new Function()();`,
     expected: undefined,
   },
-  {src: `(new Function).length;`, expected: 0},
-  {src: `(new Function).toString()`, expected: 'function() {}'},
+  {src: `(new Function()).length;`, expected: 0},
+  {src: `new Function().toString()`, expected: 'function() {}'},
   {
-    name: 'new Function simple returns callable',
-    src: `(new Function('return 42;'))();`,
+    name: 'new Function(/* body */) returns callable',
+    src: `new Function('return 42;')();`,
     expected: 42,
   },
-  {src: `(new Function('return 42;')).length;`, expected: 0},
+  {src: `new Function(/* body */).length;`, expected: 0},
   {
-    src: `(new Function('return 42;')).toString()`,
+    src: `new Function('return 42;').toString()`,
     expected: 'function() {return 42;}'
   },
   {
-    name: 'new Function with args returns callable',
-    src: `(new Function('a, b', 'c', 'return a + b * c;'))(2, 3, 10);`,
+    name: 'new Function(/* args... */, /* body */) returns callable',
+    src: `new Function('a, b', 'c', 'return a + b * c;')(2, 3, 10);`,
     expected: 32,
   },
   {
-    name: 'new Function with args .length',
-    src: `(new Function('a, b', 'c', 'return a + b * c;')).length;`,
+    name: "(new Function('a, b', 'c', /* body */)).length",
+    src: `new Function('a, b', 'c', 'return a + b * c;').length;`,
     expected: 3,
   },
   {
-    name: 'new Function with args .toString()',
-    src: `String(new Function('a, b', 'c', 'return a + b * c;'))`,
+    name: 'new Function(/* args... */, /* body */).toString()',
+    src: `new Function('a, b', 'c', 'return a + b * c;').toString()`,
     expected: 'function(a, b,c) {return a + b * c;}',
   },
   {
@@ -1632,10 +1632,10 @@ module.exports = [
     expected: false,
   },
   {
-    name: 'Function.prototype.toString applied to non-fucntion throws',
+    name: 'Function.prototype.toString.call(/* non-function */) throws',
     src: `
       try {
-        Function.prototype.toString.apply({});
+        Function.prototype.toString.call({});
       } catch (e) {
         e.name;
       }
@@ -1643,12 +1643,10 @@ module.exports = [
     expected: 'TypeError',
   },
   {
-    name: 'Function.prototype.apply non-function throws',
+    name: 'Function.prototype.apply.call(/* non-function */) throws',
     src: `
-      var o = {};
-      o.apply = Function.prototype.apply;
       try {
-        o.apply();
+        Function.prototype.apply.call({});
       } catch (e) {
         e.name;
       }
@@ -1676,7 +1674,7 @@ module.exports = [
     expected: 0,
   },
   {
-    name: 'Function.prototype.apply(..., non-object)',
+    name: 'Function.prototype.apply(..., /* non-object */) throws',
     src: `
       try {
         (function() {}).apply(undefined, 'not an object');
@@ -1687,11 +1685,11 @@ module.exports = [
     expected: 'TypeError',
   },
   {
-    name: 'Function.prototype.apply(..., sparse)',
+    name: 'Function.prototype.apply(..., /* sparse array */)',
     src: `
       (function(a, b, c) {
         if (!(1 in arguments)) {
-          throw new Error('Argument 1 missing');
+          throw new Error('arguments[1] missing');
         }
         return a + c;
       }).apply(undefined, [1, , 3]);
@@ -1699,7 +1697,7 @@ module.exports = [
     expected: 4,
   },
   {
-    name: 'Function.prototype.apply(..., array-like)',
+    name: 'Function.prototype.apply(..., /* array-like */)',
     src: `
       (function(a, b, c) {
         return a + b + c;
@@ -1708,7 +1706,7 @@ module.exports = [
     expected: 6,
   },
   {
-    name: 'Function.prototype.apply(..., non-array-like)',
+    name: 'Function.prototype.apply(..., /* non-array-like */)',
     src: `
       (function(a, b, c) {
         return a + b + c;
@@ -1717,12 +1715,10 @@ module.exports = [
     expected: NaN  // Because undefined + undefined === NaN.,
   },
   {
-    name: 'Function.prototype.call non-function throws',
+    name: 'Function.prototype.call.call(/* non-function */) throws',
     src: `
-      var o = {};
-      o.call = Function.prototype.call;
       try {
-        o.call();
+        Function.prototype.call.call({});
       } catch (e) {
         e.name;
       }
@@ -1739,12 +1735,12 @@ module.exports = [
     expected: true,
   },
   {
-    name: 'Function.prototype.call no args',
+    name: 'Function.prototype.call() gives arguments.length === 0',
     src: `(function() {return arguments.length;}).call();`,
     expected: 0,
   },
   {
-    name: 'Function.prototype.call',
+    name: 'Function.prototype.call(..., /* sparse array */)',
     src: `
       (function(a, b, c) {
         if (!(1 in arguments)) {
@@ -1756,12 +1752,10 @@ module.exports = [
     expected: 4,
   },
   {
-    name: 'Function.prototype.bind non-function throws',
+    name: 'Function.prototype.bind.call(/* non-function */) throws',
     src: `
-      var o = {};
-      o.bind = Function.prototype.bind;
       try {
-        o.bind();
+        Function.prototype.bind.call({});
       } catch (e) {
         e.name;
       }


### PR DESCRIPTION
* Generally improve various tests names and readability.
* Make it possible for test cases in `testcases.js` to indicate they are destructive, causing them to be run in a separate `Interpreter` instance.
* Move more tests (including some destructive ones) from `interpreter_test.js` to `testcases.js`.  There are many which could yet be moved.