### PR TITLE
Improve Function and Function.prototype.toString

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -949,8 +949,10 @@ Interpreter.prototype.initFunction_ = function() {
       // are valid Identifiers.
       var argsStr = args.map(function(arg) {return String(arg);}).join(',');
       // Acorn needs to parse body in the context of a function or
-      // else 'return' statements will be syntax errors.
-      var source = '(function(' + argsStr + ') {' + body + '})';
+      // else 'return' statements will be syntax errors.  The name
+      // "anonymous" and extra line breaks were standardised in ES2019
+      // via https://tc39.es/Function-prototype-toString-revision/
+      var source = '(function anonymous(' + argsStr + '\n) {\n' + body + '\n})';
       var ast = intrp.compile_(source, state.scope.perms);
       if (ast['body'].length !== 1) {
         // Function('a', 'return a + 6;}; {alert(1);');

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -610,8 +610,6 @@ Interpreter.prototype.initBuiltins_ = function() {
   this.initPerms_();
 
   // Initialize ES standard global functions.
-  var intrp = this;
-
   var eval_ = new this.NativeFunction({
     id: 'eval', length: 1,
     /** @type {!Interpreter.NativeCallImpl} */
@@ -658,6 +656,7 @@ Interpreter.prototype.initBuiltins_ = function() {
     [decodeURI, 'decodeURI'], [decodeURIComponent, 'decodeURIComponent'],
     [encodeURI, 'encodeURI'], [encodeURIComponent, 'encodeURIComponent']
   ];
+  var intrp = this;
   for (var i = 0; i < strFunctions.length; i++) {
     var wrapper = (function(nativeFunc) {
       return function(str) {
@@ -706,8 +705,6 @@ Interpreter.prototype.initObject_ = function() {
       return this.construct.call(this, intrp, thread, state, args);
     }
   });
-
-  var intrp = this;
 
   // Static methods on Object.
   this.createNativeFunction('Object.is', Object.is, false);
@@ -1583,7 +1580,7 @@ Interpreter.prototype.initString_ = function() {
   var thisStringValue = function(intrp, value, name, perms) {
     if (typeof value === 'string') {  // String primitive.
       return value;
-    } else if (value === intrp.STRING) {  // The only Boolen object.
+    } else if (value === intrp.STRING) {  // The only String object.
       return '';
     }
     throw new intrp.Error(perms, intrp.TYPE_ERROR,
@@ -1881,7 +1878,7 @@ Interpreter.prototype.initDate_ = function() {
     }
     // Called as new Date().
     var args = [null].concat(Array.from(arguments));
-    var date = new (Function.prototype.bind.apply(Date, args));
+    var date = new (Function.prototype.bind.apply(Date, args))();
     return new intrp.Date(date, intrp.thread_.perms());
   };
   this.createNativeFunction('Date', wrapper, true);
@@ -2488,8 +2485,6 @@ Interpreter.prototype.initPerms_ = function() {
  * @private
  */
 Interpreter.prototype.initNetwork_ = function() {
-  var intrp = this;
-
   new this.NativeFunction({
     id: 'CC.connectionListen', length: 2,
     /** @type {!Interpreter.NativeCallImpl} */

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1859,7 +1859,7 @@ tests.FunctionConstructor = function() {
   console.assert(f() === undefined, 'new Function() returns callable');
   console.assert(f.length === 0, 'new Function() .length');
   var actual = String(f);
-  var expected = 'function() {}';
+  var expected = 'function anonymous(\n) {\n\n}';
   console.assert(actual === expected, 'new Function() .toString() ' +
       'Actual: "' + actual + '" Expected: "' + expected + '"');
 
@@ -1867,7 +1867,7 @@ tests.FunctionConstructor = function() {
   console.assert(f() === 42, 'new Function simple returns callable');
   console.assert(f.length === 0, 'new Function simple .length');
   actual = String(f);
-  expected = 'function() {return 42;}';
+  expected = 'function anonymous(\n) {\nreturn 42;\n}';
   console.assert(actual === expected, 'new Function simple .toString() ' +
       'Actual: "' + actual + '" Expected: "' + expected + '"');
 
@@ -1875,7 +1875,7 @@ tests.FunctionConstructor = function() {
   console.assert(f(2, 3, 10) === 32, 'new Function with args returns callable');
   console.assert(f.length === 3, 'new Function with args .length');
   actual = String(f);
-  expected = 'function(a, b,c) {return a + b * c;}';
+  expected = 'function anonymous(a, b,c\n) {\nreturn a + b * c;\n}';
   console.assert(actual === expected, 'new Function with args .toString() ' +
       'Actual: "' + actual + '" Expected: "' + expected + '"');
 };

--- a/server/tests/dumper_test.js
+++ b/server/tests/dumper_test.js
@@ -1005,7 +1005,8 @@ exports.testDumperPrototypeDumpBinding = function(t) {
         ['f2', Do.SET, 'var f2 = function F2(arg) {};\n', Do.DONE],
         ['obj.f3', Do.SET, 'obj.f3 = function() {};\n', Do.DONE],
         // BUG(cpcallen): Really want '... = Function(...', due to scoping.
-        ['f4', Do.SET, 'var f4 = function(a1,a2,a3,a4, a5) {};\n', Do.DONE],
+        ['f4', Do.SET,
+         'var f4 = function anonymous(a1,a2,a3,a4, a5\n) {\n\n};\n', Do.DONE],
         // TODO(ES5): verify that f4.name gets deleted.
       ],
       after: [

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1648,6 +1648,10 @@ module.exports = [
     expected: false,
   },
   {
+    src: `Function.prototype.toString()`,
+    expected: 'function () { [native code] }'
+  },
+  {
     name: 'Function.prototype.toString.call(/* non-function */) throws',
     src: `
       try {
@@ -1672,7 +1676,7 @@ module.exports = [
       Object.setPrototypeOf(escape, function parent() {});
       escape.toString();
     `,
-    expected: 'function () { [native code] }',
+    expected: 'function escape() { [native code] }',
   },
   {
     name: 'Function.prototype.apply.call(/* non-function */) throws',

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1643,17 +1643,6 @@ module.exports = [
     expected: 'SyntaxError',
   },
   {
-    name: 'Function constructor rejects repeated parameter names',
-    src: `
-      try {
-        new Function('a', 'a', '');
-      } catch (e) {
-        e.name;
-      }
-    `,
-    expected: 'SyntaxError',
-  },
-  {
     name: 'Function.prototype has no .prototype',
     src: `Function.prototype.hasOwnProperty('prototype');`,
     expected: false,
@@ -3313,6 +3302,7 @@ module.exports = [
         '(function() {arguments = undefined;});',
         // Duplicate argument names.
         '(function(a, a) {});',
+        "new Function('a', 'a', '');",
         // Octal numeric literals.
         '0777;',
         // Delete of unqualified or undeclared identifier.

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1659,9 +1659,7 @@ module.exports = [
   },
   {
     name: 'Function constructor parameter line comments hide later parameters',
-    src: `
-      new Function('dummy //', 'escape', 'return typeof escape')(0, 0);
-    `,
+    src: `new Function('dummy //', 'escape', 'return typeof escape')(0, 0);`,
     expected: 'function',
   },
 

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1627,6 +1627,33 @@ module.exports = [
     expected: 'function(a, b,c) {return a + b * c;}',
   },
   {
+    name: 'Function constructor accepts non-ASCII parameter names',
+    src: `new Function('fußball', '').toString()`,
+    expected: 'function(fußball) {}',
+  },
+  {
+    name: 'Function constructor rejects non-unicode-letter parameter names',
+    src: `
+      try {
+        new Function('a…z', '');
+      } catch (e) {
+        e.name;
+      }
+    `,
+    expected: 'SyntaxError',
+  },
+  {
+    name: 'Function constructor rejects repeated parameter names',
+    src: `
+      try {
+        new Function('a', 'a', '');
+      } catch (e) {
+        e.name;
+      }
+    `,
+    expected: 'SyntaxError',
+  },
+  {
     name: 'Function.prototype has no .prototype',
     src: `Function.prototype.hasOwnProperty('prototype');`,
     expected: false,

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1600,16 +1600,21 @@ module.exports = [
     expected: undefined,
   },
   {src: `(new Function()).length;`, expected: 0},
-  {src: `new Function().toString()`, expected: 'function() {}'},
+  {src: `new Function().toString()`, expected: 'function anonymous(\n) {\n\n}'},
   {
     name: 'new Function(/* body */) returns callable',
     src: `new Function('return 42;')();`,
     expected: 42,
   },
+  {
+    name: 'Function constructor accepts trailing line comments in body',
+    src: `typeof new Function('//');`,
+    expected: 'function',
+  },
   {src: `new Function(/* body */).length;`, expected: 0},
   {
     src: `new Function('return 42;').toString()`,
-    expected: 'function() {return 42;}'
+    expected: 'function anonymous(\n) {\nreturn 42;\n}'
   },
   {
     name: 'new Function(/* args... */, /* body */) returns callable',
@@ -1624,12 +1629,12 @@ module.exports = [
   {
     name: 'new Function(/* args... */, /* body */).toString()',
     src: `new Function('a, b', 'c', 'return a + b * c;').toString()`,
-    expected: 'function(a, b,c) {return a + b * c;}',
+    expected: 'function anonymous(a, b,c\n) {\nreturn a + b * c;\n}',
   },
   {
     name: 'Function constructor accepts non-ASCII parameter names',
     src: `new Function('fußball', '').toString()`,
-    expected: 'function(fußball) {}',
+    expected: 'function anonymous(fußball\n) {\n\n}',
   },
   {
     name: 'Function constructor rejects non-unicode-letter parameter names',
@@ -1642,6 +1647,24 @@ module.exports = [
     `,
     expected: 'SyntaxError',
   },
+  {
+    name: 'Function constructor accepts block comments in parameter list',
+    src: `new Function('a, /*test*/b', 'c', 'return a + b * c;')(2, 4, 10)`,
+    expected: 42,
+  },
+  {
+    name: 'Function constructor accepts line comments in parameter list',
+    src: `new Function('a, b', 'c //test', 'return a + b * c;')(2, 4, 10)`,
+    expected: 42,
+  },
+  {
+    name: 'Function constructor parameter line comments hide later parameters',
+    src: `
+      new Function('dummy //', 'escape', 'return typeof escape')(0, 0);
+    `,
+    expected: 'function',
+  },
+
   {
     name: 'Function.prototype has no .prototype',
     src: `Function.prototype.hasOwnProperty('prototype');`,


### PR DESCRIPTION
This started off as a quick tidy of various things in `interpreter.js`, but in the process of sorting out a small nit I had with the `Function` constructor I re-read the  tc39 [`Function.prototype.toString revision`](https://tc39.es/Function-prototype-toString-revision/) proposal, which was adopted in ES2019, and decided it made sense to implement so far as it applies.

* Simplify the built-in `Function` constructor removing some unnecessary checks.
* Update the `function` body boilerplate that it uses to comply with the current version of the spec.  (This does not violate anything previously specified in ES5.1, which was rather vague on this point.)  Notably, it now gives every function the name `anonymous`, and adds some extra `\n`s to ensure that trailing line comments (`//`) do not cause unexpected syntax errors.
* Update some of various internal `<Foo>Function.prototype.toString` methods to comply with other provisions of the proposal, such that built-in functions will always be stringified with their original name.
* Make the other minor changes that I'd started out with or collected along the way.