### PR TITLE
Fix `Object.keys`, improve `Object.assign`

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -693,7 +693,7 @@ Interpreter.prototype.initObject_ = function() {
           typeof value === 'string') {
         // No boxed primitives in Code City.
         throw new intrp.Error(state.scope.perms, intrp.TYPE_ERROR,
-            'Boxed primitives not supported.');
+            'boxed primitives not supported');
       } else if (value === undefined || value === null) {
         return new intrp.Object(state.scope.perms);
       } else {
@@ -717,8 +717,7 @@ Interpreter.prototype.initObject_ = function() {
       // N.B.: we use ES6 definition; ES5.1 would throw TypeError if
       // passed a non-object.
       var obj = intrp.toObject(args[0], perms);
-      var keys = obj.ownKeys(state.scope.perms);
-      return intrp.createArrayFromList(keys, state.scope.perms);
+      return intrp.createArrayFromList(obj.ownKeys(perms), perms);
     }
   });
 
@@ -728,7 +727,14 @@ Interpreter.prototype.initObject_ = function() {
     call: function(intrp, thread, state, thisVal, args) {
       var perms = state.scope.perms;
       var obj = intrp.toObject(args[0], perms);
-      return intrp.createArrayFromList(obj.ownKeys(perms), perms);
+      var keys = obj.ownKeys(perms);
+      var enumerableKeys = [];
+      for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        var pd = obj.getOwnPropertyDescriptor(key, perms);
+        if (pd.enumerable) enumerableKeys.push(key);
+      }
+      return intrp.createArrayFromList(enumerableKeys, perms);
     }
   });
 

--- a/server/startup/es6.js
+++ b/server/startup/es6.js
@@ -91,24 +91,25 @@ var WeakMap = new 'WeakMap';
 ///////////////////////////////////////////////////////////////////////////////
 
 Object.assign = function assign(target, varArgs) {
-  // Polyfill adapted from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#polyfill
   // The length property of the assign method is 2.
   if (target === null || target === undefined) {
     throw new TypeError('Cannot convert undefined or null to object');
   }
-  for (var index = 1; index < arguments.length; index++) {
-    var nextSource = arguments[index];
-    if (nextSource !== null && nextSource !== undefined) {
-      for (var nextKey in nextSource) {
-        // Avoid bugs when hasOwnProperty is shadowed
-        if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-          to[nextKey] = nextSource[nextKey];
-        }
+  target = Object(target);
+
+  for (var i = 1; i < arguments.length; i++) {
+    var src = arguments[i];
+    if (src !== null && src !== undefined) {
+      var keys = Object.keys(src);
+      for (var j = 0; j < keys.length; j++) {
+        var key = keys[j];
+        target[key] = src[key];
       }
     }
   }
-  return to;
+  return target;
 };
+Object.defineProperty(Array, 'assign', {enumerable: false});
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1477,6 +1477,34 @@ module.exports = [
     expected: 82,
   },
   {
+    name: 'Object.getOwnPropertyNames',
+    src: `
+      var p = {x: 'inherited enumerable', y: 'inherited nonenumerable'};
+      var o = Object.create(p);
+      o.a = 'own enumerable';
+      o.b = 'own nonenumerable';
+      o.c = 'own enumerable';
+      Object.defineProperty(p, 'y', {enumerable: false});
+      Object.defineProperty(o, 'b', {enumerable: false});
+      Object.getOwnPropertyNames(o).toString();
+    `,
+    expected: 'a,b,c',
+  },
+  {
+    name: 'Object.keys',
+    src: `
+      var p = {x: 'inherited enumerable', y: 'inherited nonenumerable'};
+      var o = Object.create(p);
+      o.a = 'own enumerable';
+      o.b = 'own nonenumerable';
+      o.c = 'own enumerable';
+      Object.defineProperty(p, 'y', {enumerable: false});
+      Object.defineProperty(o, 'b', {enumerable: false});
+      Object.keys(o).toString();
+    `,
+    expected: 'a,c',
+  },
+  {
     name: 'Object.prototype.toString',
     src: `({}).toString();`,
     expected: '[object Object]',

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1477,6 +1477,26 @@ module.exports = [
     expected: 82,
   },
   {
+    name: 'Object.assign',
+    src: `
+      var p = {x: 'inherited enumerable', y: 'inherited nonenumerable'};
+      var o = Object.create(p);
+      o.a = 'own enumerable';
+      o.b = 'own nonenumerable';
+      o.c = 'own enumerable';
+      Object.defineProperty(p, 'y', {enumerable: false});
+      Object.defineProperty(o, 'b', {enumerable: false});
+
+      var t = {a: 'to be overwritten', b: 'not overwritten', d: 'preserved'};
+
+      Object.assign(t, o, {e: 'extra'});
+      [Object.getOwnPropertyNames(t).length,
+       t.a, t.b, t.c, t.d, t.e].toString();
+    `,
+    expected:
+      '5,own enumerable,not overwritten,own enumerable,preserved,extra',
+  },
+  {
     name: 'Object.getOwnPropertyNames',
     src: `
       var p = {x: 'inherited enumerable', y: 'inherited nonenumerable'};


### PR DESCRIPTION
* Fix the `Object.keys` builtin, which was previously returning the same thing as `Object.getOwnPropertyNames`—i.e., including non-enumerable properties.
* Improve the `Object.assign` polyfill:
  * Use `Object.keys` (now fixed!) to obtain list of enumerable own keys, and iterate over that rather than using a `for in` loop.  This avoids having to check whether the keys are own keys or inherited.
  * Make `Object.assign` non-enumerable.
* Add tests.